### PR TITLE
testing: run tRunner's deferred half on the test's own goroutine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1501,6 +1501,10 @@ name = "testing_parallel_smoke"
 path = "examples/testing_parallel_smoke.rs"
 
 [[example]]
+name = "testing_nested_parallel_smoke"
+path = "examples/testing_nested_parallel_smoke.rs"
+
+[[example]]
 name = "testing_cleanup_smoke"
 path = "examples/testing_cleanup_smoke.rs"
 

--- a/examples/testing_nested_parallel_smoke.rs
+++ b/examples/testing_nested_parallel_smoke.rs
@@ -1,0 +1,189 @@
+// testing_nested_parallel_smoke — a parallel subtest under a parallel
+// parent.
+//
+// `testing_parallel_smoke` covers one level of Parallel: a sequential
+// parent with parallel children. This is the level below it, and it is
+// where the ordering in `tRunner` stops being an implementation detail.
+//
+// A test that calls Parallel signals its parent TWICE: once when it
+// parks (Go's "Release calling test") and once when it really finishes.
+// The work Go does in tRunner's deferred func — closing the barrier,
+// waiting for the parked subtests, reporting them — belongs to the
+// SECOND signal. Doing it after the first releases nothing, because at
+// that point the parent's body has not run and `sub` is still empty; a
+// child the parent creates afterwards then parks on a barrier nobody
+// will ever close, and the run reports PASS with the child's body
+// never executed.
+//
+// Both tests below are identical except for one line — whether the
+// PARENT calls Parallel. Each has one child that calls Parallel and
+// then fails on purpose, so both runs must report FAIL, and both
+// children must have run.
+
+#![no_std]
+#![no_main]
+#![allow(non_snake_case)]
+
+extern crate alloc;
+extern crate goish;
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use goish::gostring::string;
+use goish::testing;
+use goish::{fmt, syscall};
+
+fn s(x: &str) -> string {
+    return string::from_bytes(x.as_bytes());
+}
+
+/// Set by whichever child body actually executes; reset between runs.
+static CHILD_RAN: AtomicBool = AtomicBool::new(false);
+
+/// Set by the parent's Cleanup, which Go runs only after every parallel
+/// subtest has completed. A child that never ran leaves this false.
+static CHILD_DONE_AT_CLEANUP: AtomicBool = AtomicBool::new(false);
+
+/// The parent is parallel, and so is its child.
+fn nested_parallel(t: &mut testing::T) {
+    t.Parallel();
+    t.Cleanup(|| {
+        CHILD_DONE_AT_CLEANUP.store(CHILD_RAN.load(Ordering::SeqCst), Ordering::SeqCst);
+    });
+    t.Run(s("child"), |t| {
+        t.Parallel();
+        CHILD_RAN.store(true, Ordering::SeqCst);
+        t.Error(s("deliberate"));
+    });
+}
+
+/// The same test with the parent's Parallel removed — the shape
+/// `testing_parallel_smoke` already covers, kept here as the control.
+fn sequential_parent(t: &mut testing::T) {
+    t.Cleanup(|| {
+        CHILD_DONE_AT_CLEANUP.store(CHILD_RAN.load(Ordering::SeqCst), Ordering::SeqCst);
+    });
+    t.Run(s("child"), |t| {
+        t.Parallel();
+        CHILD_RAN.store(true, Ordering::SeqCst);
+        t.Error(s("deliberate"));
+    });
+}
+
+/// Three levels of Parallel, to show the fix is not special-cased to
+/// two: the grandchild must run and its failure must reach the root.
+fn three_deep(t: &mut testing::T) {
+    t.Parallel();
+    t.Run(s("child"), |t| {
+        t.Parallel();
+        t.Run(s("grandchild"), |t| {
+            t.Parallel();
+            CHILD_RAN.store(true, Ordering::SeqCst);
+            t.Error(s("deliberate"));
+        });
+    });
+}
+
+/// Run one test alone and report whether the child body executed,
+/// whether the child had finished by the time the parent's cleanup
+/// ran, and whether the run failed. `testing::Main` returns 0 when the
+/// run passes.
+fn check(name: &'static str, f: testing::TestFn) -> (bool, bool, bool) {
+    CHILD_RAN.store(false, Ordering::SeqCst);
+    CHILD_DONE_AT_CLEANUP.store(false, Ordering::SeqCst);
+    let code = testing::Main(&[(name, f)]);
+    return (
+        CHILD_RAN.load(Ordering::SeqCst),
+        CHILD_DONE_AT_CLEANUP.load(Ordering::SeqCst),
+        code != 0,
+    );
+}
+
+#[goish::main]
+fn main() {
+    let mut failed = 0;
+
+    fmt::Println!("--- parallel parent (the FAIL is expected):");
+    let (nestedRan, nestedCleanup, nestedFailed) = check("Nested", nested_parallel);
+
+    fmt::Println!("--- sequential parent (the FAIL is expected):");
+    let (seqRan, seqCleanup, seqFailed) = check("Seq", sequential_parent);
+
+    fmt::Println!("--- three levels (the FAIL is expected):");
+    let (deepRan, _deepCleanup, deepFailed) = check("Deep", three_deep);
+    fmt::Println!("--- end");
+
+    // 1. The child under a parallel parent runs at all. Before the
+    //    barrier moved to the second signal it parked forever, and the
+    //    run still exited 0 — the silence is the dangerous part.
+    {
+        if nestedRan {
+            fmt::Println!("[ 1] nested child runs         PASS");
+        } else {
+            fmt::Println!("[ 1] nested child runs         FAIL");
+            failed += 1;
+        }
+    }
+
+    // 2. …and its failure turns the run red. A child that runs but is
+    //    reported after its parent's status line would still exit 0.
+    {
+        if nestedFailed {
+            fmt::Println!("[ 2] nested failure reported   PASS");
+        } else {
+            fmt::Println!("[ 2] nested failure reported   FAIL");
+            failed += 1;
+        }
+    }
+
+    // 3. Go: "Cleanup registers a function to be called when the test
+    //    (or subtest) AND ALL ITS SUBTESTS complete" — the parent's
+    //    cleanup runs after the barrier has released the child and the
+    //    child has finished, not when the parent's body returns.
+    {
+        if nestedCleanup {
+            fmt::Println!("[ 3] cleanup after subtests    PASS");
+        } else {
+            fmt::Println!("[ 3] cleanup after subtests    FAIL");
+            failed += 1;
+        }
+    }
+
+    // 4. The one-level case is unchanged: this is the shape that
+    //    already worked, so a fix that traded one for the other is
+    //    caught here rather than in the suite.
+    {
+        if seqRan && seqCleanup && seqFailed {
+            fmt::Println!("[ 4] sequential parent intact  PASS");
+        } else {
+            fmt::Println!(
+                "[ 4] sequential parent intact  FAIL ran=",
+                seqRan,
+                " cleanup=",
+                seqCleanup,
+                " failed=",
+                seqFailed
+            );
+            failed += 1;
+        }
+    }
+
+    // 5. Three levels of Parallel: the release has to happen at every
+    //    level, so the grandchild runs and its failure reaches the root.
+    {
+        if deepRan && deepFailed {
+            fmt::Println!("[ 5] three levels release      PASS");
+        } else {
+            fmt::Println!("[ 5] three levels release      FAIL ran=", deepRan, " failed=", deepFailed);
+            failed += 1;
+        }
+    }
+
+    if failed == 0 {
+        fmt::Println!("ok 5/5");
+        syscall::Exit(0);
+    } else {
+        fmt::Println!("FAIL", failed, "of 5");
+        syscall::Exit(1);
+    }
+}

--- a/scripts/e2e_runner.sh
+++ b/scripts/e2e_runner.sh
@@ -47,6 +47,7 @@ loops_for() {
     chan_*|select_*|preempt_*|sched_*|sync_*|spawn_*|stack_*|lockfree_*|lookpath_*|\
     time_sleep|time_timer|stopwatch|signal_smoke|signal_winch_smoke|sigaltstack_offline_proof|\
     context_*|cmd_stdout_pipe_test|syscall_fswatch_smoke|m20_smoke|\
+    testing_parallel_smoke|testing_nested_parallel_smoke|\
     goginx|https_real_smoke|http_shutdown_smoke|http_keepalive_smoke|\
     http_stream_body_smoke|\
     http_panic_demo|production_http_server|tls_smoke|tls_server_smoke)

--- a/src/testing/testing.rs
+++ b/src/testing/testing.rs
@@ -277,12 +277,21 @@ impl T {
         crate::runtime::Goexit();
     }
 
-    // go: none — goish-only: the cleanup-and-signal step Go performs in
-    // `tRunner`'s deferred call during the Goexit unwind. goish has no
-    // unwind, so both the normal return path and the Goexit path call
-    // this explicitly. Idempotent: the `reported` flag makes a second
-    // call a no-op, so a `Cleanup` callback that itself calls `FailNow`
-    // cannot re-enter it.
+    // go: none — goish-only: tRunner's two deferred calls, which Go runs
+    // during the Goexit unwind. goish has no unwind, so both the normal
+    // return path and the Goexit path call this explicitly, on a live
+    // stack. Idempotent: the `reported` flag makes a second call a
+    // no-op, so a `Cleanup` callback that itself calls `FailNow` cannot
+    // re-enter it.
+    //
+    // **This has to run on the test's OWN goroutine, when its body is
+    // done.** Go's `<-t.signal` lives in the caller (`T.Run`,
+    // `runTests`) while the release below is deferred inside the test's
+    // goroutine, so the two cannot be confused. A test that calls
+    // `Parallel` signals TWICE — once when it parks, once when it
+    // finishes — and doing the release on the first signal releases
+    // nothing: the body has not run, `sub` is still empty, and a
+    // parallel subtest created later parks on a barrier nobody closes.
     fn finish_before_goexit(&self) {
         if self
             .state
@@ -291,12 +300,109 @@ impl T {
         {
             return;
         }
-        self.drain_cleanups();
-        // Wake whoever is waiting on this test. Buffered with capacity
-        // 1 and sent exactly once, so this never blocks — which matters,
-        // because parking here would strand a test that is on its way
-        // out.
-        self.state.signal.Send(true);
+        let state = &self.state;
+
+        // Go: tRunner's INNER deferred func, `if len(t.sub) == 0 {
+        // t.runCleanup(normalPanic) }`. It is deferred last, so it runs
+        // FIRST — a test with no parallel subtests tears down before
+        // the duration below is banked, and its cleanup time counts as
+        // its own. A test WITH subtests cleans up further down instead,
+        // once they have finished: Go's Cleanup contract is "when the
+        // test and all its subtests complete".
+        if state.sub.Lock().is_empty() {
+            self.drain_cleanups();
+        }
+
+        // Go: `t.checkRaces()` first in tRunner's outer deferred func —
+        // any race this test caused is attributed to it before it is
+        // reported.
+        state.checkRaces();
+
+        // Go: tRunner's deferred func, `if t.Failed() { numFailed.Add(1) }`.
+        if state.failed.load(Ordering::Acquire) {
+            numFailed.fetch_add(1, Ordering::AcqRel);
+        }
+
+        // Go: `t.duration += highPrecisionTimeSince(t.start)`, before
+        // the report — so the reported time is the test's own, not
+        // including any wait for serial tests.
+        {
+            let start = *state.start.Lock();
+            let mut d = state.duration.Lock();
+            *d = crate::time::Duration(d.0 + crate::time::Since(start).0);
+        }
+
+        // Go: tRunner's deferred func, `if len(t.sub) > 0`. Any subtest
+        // that called Parallel is parked on this test's barrier.
+        let subs: Vec<Arc<TState>> = state.sub.Lock().clone();
+        let ts = state.tstate.Lock().clone();
+        if !subs.is_empty() {
+            // Go: "Decrease the running count for this test and mark it
+            // as no longer running" — the parent gives up its slot so a
+            // parallel child can take it.
+            if let Some(ts) = ts.as_ref() {
+                ts.release();
+            }
+            // Go: `running.Delete(t.name)` — a test waiting on its
+            // subtests is not itself running.
+            running_delete(state.name.Lock().clone());
+
+            // Go: `close(t.barrier)` — "Release the parallel subtests."
+            // Closing rather than sending is what releases ALL of them;
+            // a send would wake exactly one and hang the rest.
+            state.barrier.Close();
+
+            // Go: "Wait for subtests to complete." Each one's status
+            // line is written here, now that its final state is known.
+            for sub in subs.iter() {
+                let _ = sub.signal.Recv();
+                report_parallel_sub(state, sub);
+            }
+
+            // Go: "Run any cleanup callbacks, now that the subtests
+            // have completed", and charge their time to this test.
+            let cleanupStart = crate::time::Now();
+            self.drain_cleanups();
+            {
+                let mut d = state.duration.Lock();
+                *d = crate::time::Duration(d.0 + crate::time::Since(cleanupStart).0);
+            }
+
+            // Go: "Reacquire the count for sequential tests."
+            if !state.isParallel.load(Ordering::Acquire) {
+                if let Some(ts) = ts.as_ref() {
+                    ts.waitParallel();
+                }
+            }
+        } else if state.isParallel.load(Ordering::Acquire) {
+            // Go: "Only release the count for this test if it was run
+            // as a parallel test."
+            if let Some(ts) = ts.as_ref() {
+                ts.release();
+            }
+        }
+
+        // Go: `t.report()` — "Report after all subtests have finished."
+        // A parallel subtest is reported by its parent instead, once the
+        // barrier has released it, so it is skipped here.
+        if !state.isParallel.load(Ordering::Acquire) {
+            state.report();
+            drain_chatty();
+        }
+
+        // Go: `running.Delete(t.name)` once the test is finished.
+        running_delete(state.name.Lock().clone());
+
+        // Go: `t.done = true` in tRunner's deferred func, once the test
+        // and all its subtests have completed. `destination` reads this
+        // to re-home late output onto the nearest still-running
+        // ancestor.
+        state.done.store(true, Ordering::Release);
+
+        // Go: `t.signal <- signal`, last in the deferred func. Wake
+        // whoever is waiting on this test — its own tRunner if it never
+        // parked, otherwise the parent that closed the barrier.
+        state.signal.Send(true);
     }
 
     // go: sdk 1.25.5 testing/testing.go:1223-1227 common.Skip
@@ -460,14 +566,16 @@ impl T {
 /// `Fatal` takes down everything after it. That was goish's behaviour
 /// until `runtime::Goexit` landed: `Skip` called `syscall::Exit(0)`.
 ///
-/// **Deviations.** Go's `tRunner` carries the parallel-subtest barrier,
-/// race-error accounting, and a deferred recover that re-panics after
-/// flushing output to the root. None of those exist here yet:
-/// `t.Parallel` is not ported, goish has no race detector, and a panic
-/// in a test is already isolated per-goroutine by the runtime's own
-/// recovery path. What remains is the part that matters for
-/// correctness — spawn, wait for exactly one signal, and let the caller
-/// read the outcome out of the shared state.
+/// **Deviations.** Go's `tRunner` IS the goroutine: it runs `fn(t)` and
+/// its deferred calls do the teardown — barrier, subtests, cleanups,
+/// report, signal — while the `<-t.signal` receive sits in the caller.
+/// goish has no unwind, so the deferred half is spelled out in
+/// `finish_before_goexit`, which the test's own goroutine calls on both
+/// exit paths; tRunner keeps the caller's half and folds the receive
+/// into itself, so `T.Run` does not have to repeat it. Go's deferred
+/// recover that re-panics after flushing output to the root has no
+/// counterpart: a panic in a test is already isolated per-goroutine by
+/// the runtime's own recovery path.
 pub(crate) fn tRunner<F: FnOnce(&mut T) + Send + 'static>(t: T, fn_: F) {
     let state = t.state.clone();
     // Go: tRunner records the name on the common and marks the test —
@@ -506,83 +614,21 @@ pub(crate) fn tRunner<F: FnOnce(&mut T) + Send + 'static>(t: T, fn_: F) {
         t.finish_before_goexit();
     });
 
-    // Go: `<-t.signal`. Exactly one send happens per test, from
-    // whichever path finished it — a normal finish, or T.Parallel
-    // handing control back before it parks.
+    // Go: `<-t.signal` — but in Go this receive lives in the CALLER
+    // (`T.Run`, `runTests`), not in tRunner, and that separation is
+    // load-bearing. Everything Go defers inside the test's goroutine —
+    // closing the barrier, waiting for the parallel subtests, the
+    // cleanups, the report — runs when the BODY is done, in
+    // `finish_before_goexit`. Waiting here and releasing afterwards
+    // would conflate "handed control back" with "finished", and a test
+    // that parked in `Parallel` hands control back before its body has
+    // run at all.
+    //
+    // So exactly one send arrives here: a normal finish, or T.Parallel
+    // handing control back before it parks. A parked test's second
+    // send — the real finish — is taken by the parent, in the loop that
+    // waits for its subtests.
     let _ = state.signal.Recv();
-
-    // Go: tRunner's deferred func, `if len(t.sub) > 0`. Any subtest
-    // that called Parallel is now parked on this test's barrier.
-    let subs: Vec<Arc<TState>> = state.sub.Lock().clone();
-    if !subs.is_empty() {
-        // Go: "Decrease the running count for this test and mark it as
-        // no longer running" — the parent gives up its slot so a
-        // parallel child can take it.
-        let ts = state.tstate.Lock().clone();
-        if let Some(ts) = ts.as_ref() {
-            ts.release();
-        }
-
-        // Go: `close(t.barrier)` — "Release the parallel subtests."
-        // Closing rather than sending is what releases ALL of them;
-        // a send would wake exactly one and hang the rest.
-        state.barrier.Close();
-
-        // Go: "Wait for subtests to complete." Each one's status line
-        // is written here, now that its final pass/fail state is known.
-        for sub in subs.iter() {
-            let _ = sub.signal.Recv();
-            report_parallel_sub(&state, sub);
-        }
-
-        // Go: "Reacquire the count for sequential tests."
-        if !state.isParallel.load(Ordering::Acquire) {
-            if let Some(ts) = ts.as_ref() {
-                ts.waitParallel();
-            }
-        }
-    } else if state.isParallel.load(Ordering::Acquire) {
-        // Go: "Only release the count for this test if it was run as a
-        // parallel test."
-        let ts = state.tstate.Lock().clone();
-        if let Some(ts) = ts {
-            ts.release();
-        }
-    }
-
-    // Go: `t.checkRaces()` first in tRunner's deferred func — any race
-    // this test caused is attributed to it before it is reported.
-    state.checkRaces();
-
-    // Go: `t.duration += highPrecisionTimeSince(t.start)` in tRunner's
-    // deferred func, before the report — so the reported time is the
-    // test's own, not including any wait for serial tests.
-    {
-        let start = *state.start.Lock();
-        let mut d = state.duration.Lock();
-        *d = crate::time::Duration(d.0 + crate::time::Since(start).0);
-    }
-
-    // Go: `t.report()` — "Report after all subtests have finished."
-    // A parallel subtest is reported by its parent instead, once the
-    // barrier has released it, so it is skipped here.
-    if !state.isParallel.load(Ordering::Acquire) {
-        state.report();
-        drain_chatty();
-    }
-
-    // Go: tRunner's deferred func, `if t.Failed() { numFailed.Add(1) }`.
-    if state.failed.load(Ordering::Acquire) {
-        numFailed.fetch_add(1, Ordering::AcqRel);
-    }
-
-    // Go: `running.Delete(t.name)` once the test is finished.
-    running_delete(state.name.Lock().clone());
-
-    // Go: `t.done = true` in tRunner's deferred func, once the test and
-    // all its subtests have completed. `destination` reads this to
-    // re-home late output onto the nearest still-running ancestor.
-    state.done.store(true, Ordering::Release);
 }
 
 // ─── chatty flag / printer ───────────────────────────────────────────


### PR DESCRIPTION
A parallel subtest under a parallel parent never ran, and the run still reported PASS -- exit 0, no diagnostic, the child's body simply never executed. A suite ported from Go that calls t.Parallel() at both levels lost its subtests without changing its output.

tRunner consumed the test's own signal and then did Go's deferred-func work:

    let _ = state.signal.Recv();          // "handed control back"
    let subs = state.sub.Lock().clone();  // read as "finished"

Those are the same event only for a sequential test. T.Parallel sends on that signal when it PARKS, so for a parallel test the release block ran before the body had executed: `sub` was still empty, the `is_empty()` branch was taken, barrier.Close() never happened, and a subtest the body created afterwards parked on a barrier nobody would ever close. The parent was reported as passing, because a parallel subtest's status line is written by the parent and there was no wait to write it after.

Go does not have the confusion available: `<-t.signal` lives in the CALLER (T.Run, runTests), while the release is deferred inside the test's own goroutine and runs when fn returns. goish had folded both into tRunner.

So the deferred half moves into finish_before_goexit -- which is already goish's stand-in for that deferred call, and already runs on the test's goroutine on both exit paths (normal return, and FailNow/SkipNow before the Goexit). tRunner keeps the caller's half. A parallel test signals twice, as in Go: once at the park, taken by tRunner, and once at the real finish, taken by the parent's subtest-wait loop.

Porting the whole deferred func rather than moving the old block also fixes an ordering bug on the path that already worked. Cleanups ran when the body returned, before the parallel subtests had been released; Go's contract is "when the test AND ALL ITS SUBTESTS complete", and it charges the cleanup time to the test's duration. Go's two defers are now both here, in their LIFO order: the inner one cleans up a test with no subtests first, the outer one cleans up after the wait.

The tRunner doc comment claimed "t.Parallel is not ported", which it has been for a while. Rewritten to say where the two halves live and why.

New example testing_nested_parallel_smoke: parallel parent + parallel child, the sequential-parent control, and a three-deep chain, checking that the child runs, that its failure reaches the root, and that the parent's Cleanup sees a finished child. All 5 checks fail before this commit -- check 4 is the control, so the cleanup ordering was wrong even without nesting. Its trace now matches Go's line for line.

It joins testing_parallel_smoke in the tier-3 e2e patterns; both spawn goroutines and resume in nondeterministic order, and tier 1 ran them once. 100/100 each.

make e2e LOOPS=1: 414/414 green. cargo check --lib clean. make lint not run -- goishlint is not installed in this tree and make anchors reports MISSING_FILE for every claim, so the Go SDK it diffs against is absent too; no anchored declaration changed.