### PR TITLE
compress/bzip2: port the package, anchored, and check it against Go

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -983,6 +983,10 @@ name = "gzip_smoke"
 path = "examples/gzip_smoke.rs"
 
 [[example]]
+name = "bzip2_smoke"
+path = "examples/bzip2_smoke.rs"
+
+[[example]]
 name = "runtime_callers_smoke"
 path = "examples/runtime_callers_smoke.rs"
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,13 +2,14 @@
 
 Where the port actually stands, and how much of it is *proven* rather
 than merely counted. Numbers are regenerated with
-`scripts/port_coverage.py`; the last refresh was 2026-08-15.
+`scripts/port_coverage.py`; the last full refresh was 2026-08-15, with
+the `compress` row refreshed 2026-08-17.
 
-## The whole tree — 4432 / 11061 functions (40.1%)
+## The whole tree — 4452 / 11061 functions (40.3%)
 
 Across the 169 packages of the Go 1.25.5 standard library that have a
-goish port: **88 are at 100%**, and there are **5434 `// go:`
-provenance lines**, 3450 of them `sdk` anchors citing the exact Go
+goish port: **89 are at 100%**, and there are **5477 `// go:`
+provenance lines**, 3484 of them `sdk` anchors citing the exact Go
 file and line range.
 
 The anchors are not spread evenly, and that is the single most important
@@ -23,7 +24,7 @@ goishlint diff the port against the Go file it came from.
 | `math` | 307/661 | 46.4% | 5 |
 | `testing` | 217/247 | 87.9% | 402 |
 | `encoding` | 210/1018 | 20.6% | 125 |
-| `compress` | 122/151 | 80.8% | 0 |
+| `compress` | 142/151 | 94.0% | 42 |
 | `os` | 112/366 | 30.6% | 3 |
 | `bytes` | 84/107 | 78.5% | 1 |
 | `strings` | 76/101 | 75.2% | 1 |
@@ -36,11 +37,22 @@ Within `net`, the entire jump since the last refresh is **`net/http`,
 now complete: 639/639 functions (100.0%) across all twelve of its
 packages, with 1476 `// go:` lines** — see its section below.
 
-So: `compress` at 80.8% and `crypto/x509` at 100% are not comparable
-claims. The first means 122 functions share a name with Go's; the second
+So: `math` at 46.4% and `crypto/x509` at 100% are not comparable
+claims. The first means 307 functions share a name with Go's; the second
 means 158 functions were each diffed against the Go source and their
 outputs checked byte-for-byte against a running Go. Treat unanchored
 subtrees as working code, not as verified ports.
+
+`compress` is the clearest illustration of the gap, because both halves
+are now visible inside one subtree. Its 42 `// go:` lines — 34 of them
+`sdk` anchors — are **all** in `compress/bzip2`, ported 2026-08-17:
+20/20 functions by name and by declaration, every one citing
+its Go file and line range, and checked against Go's own test vectors
+plus seven `testdata/` corpora — 567 KB of English text, 16 KB of
+random bytes, a 1 MiB sawtooth and the issue-5747 overrun case — all
+byte-identical to a running Go. `flate`, `gzip`, `lzw` and `zlib` carry
+122 name-level ports and zero anchors between them. Same subtree, same
+percentage column, two different claims.
 
 `iter` (0/4) and `database` (0/130) have directories but no ported
 functions. `iter` is a squatter — goish fakes Go 1.23 iterator support

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ per-P, and an HTTP server with an allocation-free hot path.
 
 ## Status
 
-Active development. The e2e suite runs 417 declared examples at tiered loop counts (`make e2e`): deterministic examples once, memory-subsystem examples ×10, and the race-sensitive scheduler/chan/select/sync/timer/server families ×50. `spawn_million` still parks 1M goroutines.
+Active development. The e2e suite runs 419 declared examples at tiered loop counts (`make e2e`): deterministic examples once, memory-subsystem examples ×10, and the race-sensitive scheduler/chan/select/sync/timer/server families ×50. `spawn_million` still parks 1M goroutines.
 
 Goish is single-target: `x86_64-unknown-linux-gnu`.
 
@@ -239,7 +239,7 @@ new `runtime/pprof` user-registry with real captured stacks.
 | `math` | 307/661 (46.4%) | 5 |
 | `testing` | 217/247 (87.9%) | 402 |
 | `encoding` | 210/1018 (20.6%) | 125 |
-| `compress` | 122/151 (80.8%) | 0 |
+| `compress` | 142/151 (94.0%) | 42 |
 | `os` | 112/366 (30.6%) | 3 |
 
 The right-hand column counts *all* `// go:` lines, which is what
@@ -254,8 +254,10 @@ receiver-qualified count.
 
 Two limits on those numbers. `crypto/`, `net/` and `testing/` hold 92%
 of all anchors; outside them coverage is mostly name-level — `sync`,
-`compress`, `archive` and `text` have almost none — so treat those
-ports as working code rather than verified ports. And some
+`archive` and `text` have almost none — so treat those
+ports as working code rather than verified ports. `compress` is the
+exception in the making: `bzip2` is fully anchored (42), the other four
+packages are not. And some
 anchors name a method without its receiver, so `anchor_check.py` can
 confirm the file and line range but cannot bind the symbol uniquely.
 `--strict` fails on those; tightening them is open work.
@@ -311,7 +313,7 @@ side-channel analysis. Read this before trusting goish with anything.
 ### Standard library ports (Go 1.25-faithful)
 - **Core**: `bufio`, `bytes`, `cmp`, `context`, `errors`, `flag`, `fmt`, `io` + `io/fs`, `log` + `log/slog`, `maps`, `os` + `os/{exec, signal, user}`, `path` + `path/filepath`, `reflect` (3 tiers), `slices`, `sort`, `strconv`, `strings`, `sync` + `sync/atomic`, `syscall`, `testing` (+ `testing/fstest`), `time`, `unicode` (full case mapping) + `unicode/{utf8, utf16}`, `expvar`, `html`, `embed` (`//go:embed` as the `embed!` macro).
 - **Encoding**: `encoding/{ascii85, asn1, base32, base64, binary, csv, hex, json, pem}` - including the `encoding/json/v2` + `jsontext` port with compile-time struct codecs.
-- **Compression & archives**: `compress/{flate, gzip, lzw, zlib}`, `archive/tar`.
+- **Compression & archives**: `compress/{bzip2, flate, gzip, lzw, zlib}`, `archive/tar`.
 - **Crypto**: `crypto/{aes, cipher, chacha20, chacha20poly1305, des, ecdh, ecdsa, ed25519, hkdf, hmac, md5, pbkdf2, poly1305, rand, rc4, rsa, sha1, sha256, sha3, sha512, subtle, x509}`, plus `crypto/tls` (above) and a minimum-viable `crypto/ssh` SSH-2.0 client.
 - **Math, hashing & text**: `math` + `math/{big, bits, rand}`, `hash/{adler32, crc32, crc64, fnv, maphash}`, `container/{heap, list, ring}`, `regexp`, `mime` + `mime/{multipart, quotedprintable}`, `net/{mail, textproto, url}`, `text/tabwriter`.
 - **`golang.org/x` ports**: `x/term`, `x/sync/errgroup`, `x/text` (BCP 47 language tags + NFD normalization), plus `xxh3`.

--- a/examples/bzip2_smoke.rs
+++ b/examples/bzip2_smoke.rs
@@ -1,0 +1,357 @@
+// bzip2_smoke — compress/bzip2 against Go's own test vectors.
+//
+// Every vector here is lifted from Go 1.25.5's
+// /share/go/src/compress/bzip2/bzip2_test.go, and every expected value
+// was re-confirmed by running that package on a live Go 1.26.5
+// toolchain (AGENTS.md §10) rather than transcribed from the test's
+// comments — including the three error STRINGS, which are the sharpest
+// discriminator this port has.
+//
+// The vectors that need `testdata/` files are left out of this file —
+// goish examples are self-contained — but they were run out of band
+// against the Go tree before this landed, and all seven matched Go
+// byte-for-byte (length + FNV-1a/64 of the output):
+//
+//   e.txt.bz2                     100003 B    pass-random1.bz2   1024 B
+//   Isaac.Newton-Opticks.txt.bz2  567198 B    pass-random2.bz2     65 B
+//   random.data.bz2                16384 B    pass-sawtooth.bz2  1 MiB
+//   fail-issue5747.bz2 (RLE2 buffer overrun) rejected with Go's message
+//
+// Those cover what the hex vectors below cannot: 567 KB of English text
+// is many blocks with the Huffman tree switching every 50 symbols
+// across several selectors, and random.data is the full 256-symbol
+// alphabet.
+//
+// What each assertion discriminates:
+//
+//   * "hello world" is the whole pipeline once — header, one block,
+//     Huffman → MTF → inverse BWT → RLE1, block CRC, final CRC;
+//   * "concatenated files" is the ONLY test of the continuation path:
+//     after the final magic the reader must byte-align, read "BZ", and
+//     re-run setup() without the file magic. A reader that stops at the
+//     first stream passes everything else in this file;
+//   * "32B zeros" and "1MiB zeros" are the RLE1/RUNA/RUNB run
+//     machinery. 1MiB also forces a full 900k block and the
+//     `repeat > blockSize-bufIndex` bound;
+//   * "RLE1 stage" is Go's own random vector chosen to hit the
+//     four-equal-bytes-plus-count encoding, which readFromBlock
+//     unwinds lazily across Read calls;
+//   * the three failure vectors each name a DIFFERENT rejection, and
+//     the message is checked, not just the fact of an error: an
+//     out-of-range selector must surface the bit reader's latched
+//     io.ErrUnexpectedEOF (not a structural complaint about the zeros
+//     a failed read handed back), a bad block size must be caught by
+//     the repeat bound, and a bad Huffman delta by the 1..20 length
+//     range. Collapsing any two of those into one error would still
+//     "fail correctly" and be wrong;
+//   * truncation mid-stream must be io.ErrUnexpectedEOF, never io.EOF
+//     and never a hang;
+//   * Read(nil) returns (0, nil) — Go's TestZeroRead. A reader that
+//     decodes eagerly before checking len(buf) returns 0, io.EOF here;
+//   * the bitReader and MTF vectors are Go's TestBitReader / TestMTF,
+//     unit-testing the two pieces the block decoder is built on.
+
+#![no_std]
+#![no_main]
+#![allow(non_snake_case, non_upper_case_globals)]
+
+extern crate alloc;
+extern crate goish;
+
+use alloc::vec::Vec;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use goish::bytes;
+use goish::compress::bzip2;
+use goish::compress::bzip2::bit_reader::newBitReader;
+use goish::compress::bzip2::move_to_front::newMTFDecoderWithRange;
+use goish::encoding::hex;
+use goish::fmt;
+use goish::goslice::slice;
+use goish::io;
+use goish::string;
+use goish::types::{byte, int, uint};
+
+static FAILED: AtomicUsize = AtomicUsize::new(0);
+
+fn check(name: &'static str, ok: bool, detail: string) {
+    if ok {
+        fmt::Printf!("PASS: %s\n", name);
+    } else {
+        FAILED.fetch_add(1, Ordering::Relaxed);
+        fmt::Printf!("FAIL: %s — %s\n", name, detail);
+    }
+}
+
+/// Go's `mustDecodeHex` — panics on a malformed literal, as Go's does.
+fn mustDecodeHex(s: &str) -> slice<byte> {
+    let (b, err) = hex::DecodeString(s);
+    if !err.IsNil() {
+        panic!("bad hex vector in bzip2_smoke");
+    }
+    return b;
+}
+
+fn from_bytes(b: &[byte]) -> slice<byte> {
+    let mut v: Vec<byte> = Vec::with_capacity(b.len());
+    v.extend_from_slice(b);
+    return slice::__from_vec(v);
+}
+
+/// Decompress `input`, returning the bytes and the terminal error.
+fn decompress(input: slice<byte>) -> (slice<byte>, goish::error) {
+    let mut r = bzip2::NewReader(bytes::NewReader(input));
+    return io::ReadAll(&mut r);
+}
+
+fn equal(got: &slice<byte>, want: &slice<byte>) -> bool {
+    if got.Len() != want.Len() {
+        return false;
+    }
+    for (i, v) in goish::range!(got) {
+        if *v != want[i] {
+            return false;
+        }
+    }
+    return true;
+}
+
+/// A decode that must succeed and match `want` exactly.
+fn wantBytes(name: &'static str, inputHex: &str, want: slice<byte>) {
+    let (got, err) = decompress(mustDecodeHex(inputHex));
+    if !err.IsNil() {
+        check(name, false, fmt::Sprintf!("unexpected error: %v", err));
+        return;
+    }
+    check(
+        name,
+        equal(&got, &want),
+        fmt::Sprintf!("got %d bytes, want %d", got.Len(), want.Len()),
+    );
+}
+
+/// A decode that must fail with exactly `wantErr` as its message.
+fn wantError(name: &'static str, inputHex: &str, wantErr: &'static str) {
+    let (_, err) = decompress(mustDecodeHex(inputHex));
+    if err.IsNil() {
+        check(name, false, string::from("unexpected success"));
+        return;
+    }
+    let got = err.Error();
+    let gv: &str = got.as_ref();
+    check(name, gv == wantErr, fmt::Sprintf!("err = %q", got));
+}
+
+// ─── the vectors ───────────────────────────────────────────────────────
+
+const helloWorld: &str = concat!(
+    "425a68393141592653594eece83600000251800010400006449080200031064c",
+    "4101a7a9a580bb9431f8bb9229c28482776741b0",
+);
+
+const concatenated: &str = concat!(
+    "425a68393141592653594eece83600000251800010400006449080200031064c",
+    "4101a7a9a580bb9431f8bb9229c28482776741b0425a68393141592653594eec",
+    "e83600000251800010400006449080200031064c4101a7a9a580bb9431f8bb92",
+    "29c28482776741b0",
+);
+
+const zeros32: &str = concat!(
+    "425a6839314159265359b5aa5098000000600040000004200021008283177245",
+    "385090b5aa5098",
+);
+
+const zeros1MiB: &str = concat!(
+    "425a683931415926535938571ce50008084000c0040008200030cc0529a60806",
+    "c4201e2ee48a70a12070ae39ca",
+);
+
+const rle1Stage: &str = concat!(
+    "425a6839314159265359d992d0f60000137dfe84020310091c1e280e100e0428",
+    "01099210094806c0110002e70806402000546034000034000000f28300000320",
+    "00d3403264049270eb7a9280d308ca06ad28f6981bee1bf8160727c7364510d7",
+    "3a1e123083421b63f031f63993a0f40051fbf177245385090d992d0f60",
+);
+
+const rle1Output: &str = concat!(
+    "92d5652616ac444a4a04af1a8a3964aca0450d43d6cf233bd03233f4ba92f871",
+    "9e6c2a2bd4f5f88db07ecd0da3a33b263483db9b2c158786ad6363be35d17335",
+    "ba",
+);
+
+/// Go issue 8363.
+const outOfRangeSelector: &str = concat!(
+    "425a68393141592653594eece83600000251800010400006449080200031064c",
+    "4101a7a9a580bb943117724538509000000000",
+);
+
+/// Go issue 13941.
+const badBlockSize: &str = concat!(
+    "425a683131415926535936dc55330063ffc0006000200020a40830008b0008b8",
+    "bb9229c28481b6e2a998",
+);
+
+const badHuffmanDelta: &str = concat!(
+    "425a6836314159265359b1f7404b000000400040002000217d184682ee48a70a",
+    "12163ee80960",
+);
+
+/// `helloWorld` cut off inside the first block.
+const truncated: &str = "425a68393141592653594eece836000002518000104000064490";
+
+#[goish::main]
+fn main() {
+    goish::go!(stack(1024 * 1024), move || {
+        run();
+    });
+    goish::runtime::sched::schedule();
+}
+
+fn run() {
+    // 1. the whole pipeline, once.
+    wantBytes(
+        "hello world",
+        helloWorld,
+        goish::convert::bytes("hello world\n"),
+    );
+
+    // 2. a second stream concatenated onto the first.
+    wantBytes(
+        "concatenated files",
+        concatenated,
+        goish::convert::bytes("hello world\nhello world\n"),
+    );
+
+    // 3-4. the RLE / RUNA / RUNB run machinery, small and full-block.
+    wantBytes("32B zeros", zeros32, goish::make!([]byte, 32));
+    wantBytes("1MiB zeros", zeros1MiB, goish::make!([]byte, 1 << 20));
+
+    // 5. Go's random vector that exercises the RLE1 stage.
+    wantBytes("random data — RLE1 stage", rle1Stage, mustDecodeHex(rle1Output));
+
+    // 6-8. three distinct rejections, checked by message.
+    wantError(
+        "out-of-range selector (issue 8363)",
+        outOfRangeSelector,
+        "unexpected EOF",
+    );
+    wantError(
+        "bad block size (issue 13941)",
+        badBlockSize,
+        "bzip2 data invalid: repeats past end of block",
+    );
+    wantError(
+        "bad huffman delta",
+        badHuffmanDelta,
+        "bzip2 data invalid: Huffman length out of range",
+    );
+
+    // 9. truncation is ErrUnexpectedEOF, not EOF and not a hang.
+    wantError("truncated stream", truncated, "unexpected EOF");
+
+    // 10. Go's TestZeroRead: Read(nil) is (0, nil), not (0, io.EOF).
+    test_zero_read();
+
+    // 11-12. the two building blocks, on Go's unit vectors.
+    test_bit_reader();
+    test_mtf();
+
+    let f = FAILED.load(Ordering::Relaxed);
+    if f == 0 {
+        fmt::Printf!("BZIP2_OK\n");
+        goish::os::Exit(0);
+    }
+    fmt::Printf!("BZIP2_FAIL (%d)\n", f as i64);
+    goish::os::Exit(1);
+}
+
+/// Go's `TestZeroRead`.
+fn test_zero_read() {
+    let mut r = bzip2::NewReader(bytes::NewReader(mustDecodeHex(zeros32)));
+    let mut empty = slice::<byte>::new();
+    let (n, err) = r.Read(&mut empty);
+    check(
+        "Read(nil) = (0, nil)",
+        n == 0 && err.IsNil(),
+        fmt::Sprintf!("n = %d", n),
+    );
+}
+
+/// Go's `TestBitReader` — nine reads over a fixed 8-byte source, the
+/// last of which must run off the end and latch an error.
+fn test_bit_reader() {
+    // Go: rd := bytes.NewReader([]byte{0xab, 0x12, 0x34, 0x56, 0x78, 0x71, 0x3f, 0x8d})
+    let src = from_bytes(&[0xab, 0x12, 0x34, 0x56, 0x78, 0x71, 0x3f, 0x8d]);
+    let mut br = newBitReader(bytes::NewReader(src));
+
+    // (nbits, value, fail)
+    let vectors: [(uint, int, bool); 9] = [
+        (1, 1, false),
+        (1, 0, false),
+        (1, 1, false),
+        (5, 11, false),
+        (32, 0x12345678, false),
+        (15, 14495, false),
+        (3, 6, false),
+        (6, 13, false),
+        (1, 0, true),
+    ];
+
+    let mut ok = true;
+    let mut detail = string::from("");
+    for i in 0..vectors.len() {
+        let (nbits, want, wantFail) = vectors[i];
+        let got = br.ReadBits(nbits);
+        let failed = !br.Err().IsNil();
+        if failed != wantFail {
+            ok = false;
+            detail = fmt::Sprintf!("vector %d: failure = %v, want %v", i as i64, failed, wantFail);
+            break;
+        }
+        if !wantFail && got != want {
+            ok = false;
+            detail = fmt::Sprintf!("vector %d: ReadBits = %d, want %d", i as i64, got, want);
+            break;
+        }
+    }
+    check("bitReader: Go's TestBitReader vectors", ok, detail);
+}
+
+/// Go's `TestMTF` — five decodes over the 0..4 identity list. The
+/// comments are Go's, and record the list state AFTER each decode.
+fn test_mtf() {
+    let mut mtf = newMTFDecoderWithRange(5);
+
+    // (idx, sym)
+    let vectors: [(int, byte); 5] = [
+        (1, 1), // [1 0 2 3 4]
+        (0, 1), // [1 0 2 3 4]
+        (1, 0), // [0 1 2 3 4]
+        (4, 4), // [4 0 1 2 3]
+        (1, 0), // [0 4 1 2 3]
+    ];
+
+    let mut ok = true;
+    let mut detail = string::from("");
+    for i in 0..vectors.len() {
+        let (idx, want) = vectors[i];
+        let sym = mtf.Decode(idx);
+        if sym != want {
+            ok = false;
+            detail = fmt::Sprintf!(
+                "vector %d: Decode(%d) = %d, want %d",
+                i as i64,
+                idx,
+                sym as i64,
+                want as i64
+            );
+            break;
+        }
+    }
+    // The list must also still read back its front symbol.
+    if ok && mtf.First() != 0 {
+        ok = false;
+        detail = string::from("First() != 0 after the five decodes");
+    }
+    check("moveToFrontDecoder: Go's TestMTF vectors", ok, detail);
+}

--- a/src/compress/bzip2/bit_reader.rs
+++ b/src/compress/bzip2/bit_reader.rs
@@ -1,0 +1,145 @@
+// go: file compress/bzip2/bit_reader.go decls: bitReader, newBitReader, bitReader.ReadBits64, bitReader.ReadBits, bitReader.ReadBit, bitReader.Err
+//
+// compress/bzip2/bit_reader.go — MSB-first bit reader over an
+// `io.ByteReader`. bzip2 packs everything (magics, the 24-bit origPtr,
+// the Huffman code lengths, the symbol stream) at bit granularity with
+// no byte alignment between fields, so every other file in the package
+// reads through this type.
+//
+// The Read* methods deliberately do NOT return an error — Go's comment
+// says the error handling was too verbose — so a failed read yields 0
+// and latches `br.err`, which callers check once via `Err()`.
+//
+// Slim deviation:
+//   * Go's `newBitReader(r io.Reader)` does `r.(io.ByteReader)` and
+//     only wraps in a `bufio.Reader` when the assertion misses. goish
+//     has no runtime type assertion on a concrete generic (AGENTS.md
+//     §9b), so it wraps unconditionally — the same choice `flate` and
+//     `lzw` made. Behaviour is identical; an already-buffered source
+//     just pays one extra layer of buffering. Go's `NewReader` doc
+//     already warns that a non-ByteReader source "may read more data
+//     than necessary", which is the only observable difference.
+
+#![allow(non_snake_case, non_camel_case_types)]
+
+use crate::bufio;
+use crate::convert::{int as toint, uint64 as touint64};
+use crate::errors::{error, nil};
+use crate::io::{self, ByteReader};
+use crate::types::{int, uint, uint64};
+
+// go: sdk 1.25.5 compress/bzip2/bit_reader.go:12-20 bitReader
+/// `bzip2.bitReader` — wraps an `io.ByteReader` and reads values
+/// bit-by-bit from it. `n` holds the bits read so far but not yet
+/// consumed, right-aligned; `bits` counts how many of them are valid.
+pub struct bitReader<R: ByteReader> {
+    // Go: r io.ByteReader
+    pub(super) r: R,
+    // Go: n uint64
+    pub(super) n: uint64,
+    // Go: bits uint
+    pub(super) bits: uint,
+    // Go: err error
+    pub(super) err: error,
+}
+
+// go: sdk 1.25.5 compress/bzip2/bit_reader.go:23-30 newBitReader
+/// `bzip2.newBitReader(r)` — a new bitReader reading from `r`. The
+/// source is wrapped in a `bufio.Reader` to obtain `ReadByte` (see the
+/// slim deviation in the file header).
+pub fn newBitReader<R: io::Reader>(r: R) -> bitReader<bufio::Reader<R>> {
+    // Go: byter, ok := r.(io.ByteReader); if !ok { byter = bufio.NewReader(r) }
+    // Go: return bitReader{r: byter}
+    return bitReader {
+        r: bufio::NewReader(r),
+        n: 0,
+        bits: 0,
+        err: nil,
+    };
+}
+
+impl<R: ByteReader> bitReader<R> {
+    // go: sdk 1.25.5 compress/bzip2/bit_reader.go:33-67 bitReader.ReadBits64
+    /// `(br *bitReader).ReadBits64(bits)` — read `bits` bits and return
+    /// them in the least-significant part of a `uint64`. On error it
+    /// returns 0 and latches the error for [`bitReader::Err`].
+    pub fn ReadBits64(&mut self, bits: uint) -> uint64 {
+        // Go: for bits > br.bits
+        while bits > self.bits {
+            // Go: b, err := br.r.ReadByte()
+            let (b, mut err) = self.r.ReadByte();
+            // Go: if err == io.EOF { err = io.ErrUnexpectedEOF }
+            if err == io::EOF {
+                err = io::ErrUnexpectedEOF.into();
+            }
+            // Go: if err != nil { br.err = err; return 0 }
+            if !err.IsNil() {
+                self.err = err;
+                return 0;
+            }
+            // Go: br.n <<= 8; br.n |= uint64(b); br.bits += 8
+            self.n <<= 8;
+            self.n |= touint64(b);
+            self.bits += 8;
+        }
+
+        // br.n looks like this (assuming that br.bits = 14 and bits = 6):
+        // Bit: 111111
+        //      5432109876543210
+        //
+        //         (6 bits, the desired output)
+        //        |-----|
+        //        V     V
+        //      0101101101001110
+        //        ^            ^
+        //        |------------|
+        //           br.bits (num valid bits)
+        //
+        // The next line right shifts the desired bits into the
+        // least-significant places and masks off anything above.
+        //
+        // Go: n = (br.n >> (br.bits - bits)) & ((1 << bits) - 1)
+        //
+        // Go's shift count is not masked and not a panic: `1 << 64` on
+        // a uint64 is 0, so the mask becomes all-ones. Rust panics on a
+        // shift that wide, so the saturating arm is spelled out. Every
+        // in-tree caller passes bits <= 48, so the arm is defensive
+        // only — it exists so a future caller cannot turn a Go
+        // no-op into an abort.
+        let mask: uint64 = if bits >= 64 {
+            u64::MAX
+        } else {
+            (1u64 << bits) - 1
+        };
+        let n = (self.n >> (self.bits - bits)) & mask;
+        // Go: br.bits -= bits
+        self.bits -= bits;
+        return n;
+    }
+
+    // go: sdk 1.25.5 compress/bzip2/bit_reader.go:70-72 bitReader.ReadBits
+    /// `(br *bitReader).ReadBits(bits)` — [`ReadBits64`] narrowed to
+    /// `int`. Every field bzip2 reads this way is at most 32 bits wide.
+    ///
+    /// [`ReadBits64`]: bitReader::ReadBits64
+    pub fn ReadBits(&mut self, bits: uint) -> int {
+        // Go: n64 := br.ReadBits64(bits); return int(n64)
+        let n64 = self.ReadBits64(bits);
+        return toint(n64);
+    }
+
+    // go: sdk 1.25.5 compress/bzip2/bit_reader.go:75-77 bitReader.ReadBit
+    /// `(br *bitReader).ReadBit()` — one bit as a bool.
+    pub fn ReadBit(&mut self) -> bool {
+        // Go: n := br.ReadBits(1); return n != 0
+        let n = self.ReadBits(1);
+        return n != 0;
+    }
+
+    // go: sdk 1.25.5 compress/bzip2/bit_reader.go:80-81 bitReader.Err
+    /// `(br *bitReader).Err()` — the latched error, nil if none.
+    pub fn Err(&self) -> error {
+        // Go: return br.err
+        return self.err.clone();
+    }
+}

--- a/src/compress/bzip2/bzip2.rs
+++ b/src/compress/bzip2/bzip2.rs
@@ -1,0 +1,756 @@
+// go: file compress/bzip2/bzip2.go decls: StructuralError, StructuralError.Error, reader, NewReader, bzip2FileMagic, bzip2BlockMagic, bzip2FinalMagic, reader.setup, reader.Read, reader.readFromBlock, reader.read, reader.readBlock, inverseBWT, crctab, updateCRC
+//
+// compress/bzip2/bzip2.go — the decompressor proper.
+//
+// There's no RFC for bzip2. Go's port used the Wikipedia page for
+// reference and a lot of guessing: https://en.wikipedia.org/wiki/Bzip2
+//
+// A bzip2 stream is a sequence of blocks. Each block is decoded whole
+// (Huffman → move-to-front → inverse Burrows-Wheeler), leaving the
+// still-run-length-encoded bytes in `tt`; the final RLE1 stage is then
+// unwound lazily by `readFromBlock` so a 900 KB block doesn't need a
+// worst-case expansion buffer.
+//
+// Slim deviations:
+//   * Go's `NewReader` returns `io.Reader`; goish returns the concrete
+//     `reader<R>`, which implements `io::Reader`. Same choice `flate`,
+//     `gzip` and `lzw` made — goish has no trait-object ReadCloser and
+//     a concrete return keeps the source generic without boxing.
+//   * `bz2.preRLE = bz2.tt[:bufIndex]` aliases one backing array in Go;
+//     goish's subslice copies (goslice.rs:17), so `preRLE` becomes an
+//     independent buffer. That is observationally identical here: `tt`
+//     is pure scratch, rewritten from index 0 by the next `readBlock`,
+//     and nothing reads it between the two. The cost is one copy of the
+//     decoded block per block.
+//   * Go builds `crctab` in a package `init()`. goish has no package
+//     init, so the table is a `const fn` evaluated at compile time —
+//     no lock, no lazy slot, no startup work. The one `as` cast in it
+//     is unavoidable: goish's `uint32(x)` conversion is not `const fn`.
+
+#![allow(non_snake_case, non_upper_case_globals, non_camel_case_types)]
+
+use crate::bufio;
+use crate::convert::{byte as tobyte, int as toint, uint as touint, uint32 as touint32};
+use crate::errors::{self, error, nil, ErrorTrait};
+use crate::goarray::array;
+use crate::goslice::slice;
+use crate::gostring::string;
+use crate::io;
+use crate::types::{byte, int, uint, uint32};
+
+use super::bit_reader::{bitReader, newBitReader};
+use super::huffman::{huffmanTree, newHuffmanTree};
+use super::move_to_front::{newMTFDecoder, newMTFDecoderWithRange};
+
+// go: sdk 1.25.5 compress/bzip2/bzip2.go:15-17 StructuralError
+/// `bzip2.StructuralError` — returned when the bzip2 data is found to
+/// be syntactically invalid. Go declares it as `type StructuralError
+/// string`; goish spells that as a newtype over `string`, matching
+/// `flate::InternalError`.
+#[derive(Clone, Debug, Default)]
+pub struct StructuralError(pub string);
+
+// go: sdk 1.25.5 compress/bzip2/bzip2.go:19-20 StructuralError.Error
+impl ErrorTrait for StructuralError {
+    /// `(s StructuralError).Error()` — `"bzip2 data invalid: " + s`.
+    fn Error(&self) -> string {
+        // Go: return "bzip2 data invalid: " + string(s)
+        return string::from("bzip2 data invalid: ") + self.0.clone();
+    }
+}
+
+// go: none — goish idiom: Go writes `StructuralError("…")` at every use
+// site, which is a TYPE CONVERSION of an untyped string constant, not a
+// call. goish cannot spell a conversion into a newtype, and every site
+// additionally has to lift the concrete type into `error`, so the pair
+// gets one name.
+/// Lift a `StructuralError` into the `error` interface.
+pub(super) fn structuralError<S: Into<string>>(s: S) -> error {
+    return errors::Wrap(StructuralError(s.into()));
+}
+
+// go: sdk 1.25.5 compress/bzip2/bzip2.go:23-40 reader
+/// `bzip2.reader` — decompresses bzip2 compressed data. Public here
+/// only because `NewReader` returns it (Go returns the `io.Reader`
+/// interface instead); the Go name is kept per AGENTS.md §5.
+pub struct reader<R: io::Reader> {
+    // Go: br bitReader
+    pub(super) br: bitReader<bufio::Reader<R>>,
+    // Go: fileCRC uint32
+    fileCRC: uint32,
+    // Go: blockCRC uint32
+    blockCRC: uint32,
+    // Go: wantBlockCRC uint32
+    wantBlockCRC: uint32,
+    // Go: setupDone bool — true if we have parsed the bzip2 header.
+    setupDone: bool,
+    // Go: eof bool
+    eof: bool,
+    // Go: blockSize int — blockSize in bytes, i.e. 900 * 1000.
+    blockSize: int,
+    // Go: c [256]uint — the ``C'' array for the inverse BWT.
+    c: array<uint, 256>,
+    // Go: tt []uint32 — mirrors the ``tt'' array in the bzip2 source and
+    // contains the P array in the upper 24 bits.
+    tt: slice<uint32>,
+    // Go: tPos uint32 — Index of the next output byte in tt.
+    tPos: uint32,
+
+    // Go: preRLE []uint32 — contains the RLE data still to be processed.
+    preRLE: slice<uint32>,
+    // Go: preRLEUsed int — number of entries of preRLE used.
+    preRLEUsed: int,
+    // Go: lastByte int — the last byte value seen.
+    lastByte: int,
+    // Go: byteRepeats uint — the number of repeats of lastByte seen.
+    byteRepeats: uint,
+    // Go: repeats uint — the number of copies of lastByte to output.
+    repeats: uint,
+}
+
+// go: sdk 1.25.5 compress/bzip2/bzip2.go:43-49 NewReader
+/// `bzip2.NewReader(r)` — a reader which decompresses bzip2 data from
+/// `r`. The source is wrapped for byte-at-a-time reads, so the
+/// decompressor may read more data than necessary from `r`.
+pub fn NewReader<R: io::Reader>(r: R) -> reader<R> {
+    // Go: bz2 := new(reader); bz2.br = newBitReader(r); return bz2
+    //
+    // goish cannot zero a `reader<R>` before its bitReader exists (the
+    // field owns `r`), so the zero value is spelled at construction.
+    return reader {
+        br: newBitReader(r),
+        fileCRC: 0,
+        blockCRC: 0,
+        wantBlockCRC: 0,
+        setupDone: false,
+        eof: false,
+        blockSize: 0,
+        c: array::default(),
+        tt: slice::new(),
+        tPos: 0,
+        preRLE: slice::new(),
+        preRLEUsed: 0,
+        lastByte: 0,
+        byteRepeats: 0,
+        repeats: 0,
+    };
+}
+
+// go: sdk 1.25.5 compress/bzip2/bzip2.go:52-52 bzip2FileMagic
+/// `bzip2FileMagic` — "BZ".
+const bzip2FileMagic: int = 0x425a;
+// go: sdk 1.25.5 compress/bzip2/bzip2.go:53-53 bzip2BlockMagic
+/// `bzip2BlockMagic` — the 48-bit magic that opens every block.
+const bzip2BlockMagic: u64 = 0x314159265359;
+// go: sdk 1.25.5 compress/bzip2/bzip2.go:54-54 bzip2FinalMagic
+/// `bzip2FinalMagic` — the 48-bit magic that closes a stream.
+const bzip2FinalMagic: u64 = 0x177245385090;
+
+impl<R: io::Reader> reader<R> {
+    // go: sdk 1.25.5 compress/bzip2/bzip2.go:56-82 reader.setup
+    /// `(bz2 *reader).setup(needMagic)` — parse the bzip2 header.
+    fn setup(&mut self, needMagic: bool) -> error {
+        // Go: br := &bz2.br — spelled inline below; a live `&mut` on the
+        // field would collide with the `bz2.tt` write at the end.
+
+        // Go: if needMagic { magic := br.ReadBits(16); … }
+        if needMagic {
+            let magic = self.br.ReadBits(16);
+            if magic != bzip2FileMagic {
+                return structuralError("bad magic value");
+            }
+        }
+
+        // Go: t := br.ReadBits(8); if t != 'h' { … }
+        let t = self.br.ReadBits(8);
+        if t != toint(b'h') {
+            return structuralError("non-Huffman entropy encoding");
+        }
+
+        // Go: level := br.ReadBits(8); if level < '1' || level > '9' { … }
+        let level = self.br.ReadBits(8);
+        if level < toint(b'1') || level > toint(b'9') {
+            return structuralError("invalid compression level");
+        }
+
+        // Go: bz2.fileCRC = 0
+        self.fileCRC = 0;
+        // Go: bz2.blockSize = 100 * 1000 * (level - '0')
+        self.blockSize = 100 * 1000 * (level - toint(b'0'));
+        // Go: if bz2.blockSize > len(bz2.tt) { bz2.tt = make([]uint32, bz2.blockSize) }
+        if self.blockSize > self.tt.Len() {
+            self.tt = crate::make!([]uint32, self.blockSize);
+        }
+        return nil;
+    }
+
+    // go: sdk 1.25.5 compress/bzip2/bzip2.go:85-107 reader.Read
+    /// `(bz2 *reader).Read(buf)` — `io.Reader`. The bit reader's latched
+    /// error wins over the decode error, so a truncated stream reports
+    /// `io.ErrUnexpectedEOF` rather than a structural complaint about
+    /// the zeros a failed read handed back.
+    pub fn Read(&mut self, buf: &mut slice<byte>) -> (int, error) {
+        // Go: if bz2.eof { return 0, io.EOF }
+        if self.eof {
+            return (0, io::EOF.into());
+        }
+
+        // Go: if !bz2.setupDone { … }
+        if !self.setupDone {
+            let mut err = self.setup(true);
+            let brErr = self.br.Err();
+            if !brErr.IsNil() {
+                err = brErr;
+            }
+            if !err.IsNil() {
+                return (0, err);
+            }
+            self.setupDone = true;
+        }
+
+        // Go: n, err = bz2.read(buf)
+        let (n, mut err) = self.read(buf);
+        let brErr = self.br.Err();
+        if !brErr.IsNil() {
+            err = brErr;
+        }
+        return (n, err);
+    }
+
+    // go: sdk 1.25.5 compress/bzip2/bzip2.go:110-160 reader.readFromBlock
+    /// `(bz2 *reader).readFromBlock(buf)` — unwind the RLE1 stage of the
+    /// current block into `buf`, returning how many bytes were produced.
+    fn readFromBlock(&mut self, buf: &mut slice<byte>) -> int {
+        // bzip2 is a block based compressor, except that it has a run-length
+        // preprocessing step. The block based nature means that we can
+        // preallocate fixed-size buffers and reuse them. However, the RLE
+        // preprocessing would require allocating huge buffers to store the
+        // maximum expansion. Thus we process blocks all at once, except for
+        // the RLE which we decompress as required.
+        // Go: n := 0
+        let mut n: int = 0;
+        // Go: for (bz2.repeats > 0 || bz2.preRLEUsed < len(bz2.preRLE)) && n < len(buf)
+        while (self.repeats > 0 || self.preRLEUsed < self.preRLE.Len()) && n < buf.Len() {
+            // We have RLE data pending.
+
+            // The run-length encoding works like this:
+            // Any sequence of four equal bytes is followed by a length
+            // byte which contains the number of repeats of that byte to
+            // include. (The number of repeats can be zero.) Because we are
+            // decompressing on-demand our state is kept in the reader
+            // object.
+
+            // Go: if bz2.repeats > 0 { … continue }
+            if self.repeats > 0 {
+                buf[n] = tobyte(self.lastByte);
+                n += 1;
+                self.repeats -= 1;
+                if self.repeats == 0 {
+                    self.lastByte = -1;
+                }
+                continue;
+            }
+
+            // Go: bz2.tPos = bz2.preRLE[bz2.tPos]; b := byte(bz2.tPos)
+            self.tPos = self.preRLE[self.tPos];
+            let b = tobyte(self.tPos);
+            self.tPos >>= 8;
+            self.preRLEUsed += 1;
+
+            // Go: if bz2.byteRepeats == 3 { … continue }
+            if self.byteRepeats == 3 {
+                self.repeats = touint(b);
+                self.byteRepeats = 0;
+                continue;
+            }
+
+            // Go: if bz2.lastByte == int(b) { bz2.byteRepeats++ } else { bz2.byteRepeats = 0 }
+            if self.lastByte == toint(b) {
+                self.byteRepeats += 1;
+            } else {
+                self.byteRepeats = 0;
+            }
+            self.lastByte = toint(b);
+
+            buf[n] = b;
+            n += 1;
+        }
+
+        return n;
+    }
+
+    // go: sdk 1.25.5 compress/bzip2/bzip2.go:163-232 reader.read
+    /// `(bz2 *reader).read(buf)` — drain the current block, then walk
+    /// the block/final magics, verifying CRCs and honouring a
+    /// concatenated second file.
+    fn read(&mut self, buf: &mut slice<byte>) -> (int, error) {
+        loop {
+            // Go: n := bz2.readFromBlock(buf)
+            let n = self.readFromBlock(buf);
+            // Go: if n > 0 || len(buf) == 0 { … }
+            if n > 0 || buf.Len() == 0 {
+                // Go: bz2.blockCRC = updateCRC(bz2.blockCRC, buf[:n])
+                self.blockCRC = updateCRC(self.blockCRC, &buf.slice(0, n));
+                return (n, nil);
+            }
+
+            // End of block. Check CRC.
+            // Go: if bz2.blockCRC != bz2.wantBlockCRC { … }
+            if self.blockCRC != self.wantBlockCRC {
+                self.br.err = structuralError("block checksum mismatch");
+                return (0, self.br.err.clone());
+            }
+
+            // Find next block.
+            // Go: br := &bz2.br; switch br.ReadBits64(48) { … }
+            let magic = self.br.ReadBits64(48);
+            if magic == bzip2BlockMagic {
+                // Start of block.
+                // Go: err := bz2.readBlock(); if err != nil { return 0, err }
+                let err = self.readBlock();
+                if !err.IsNil() {
+                    return (0, err);
+                }
+            } else if magic == bzip2FinalMagic {
+                // Check end-of-file CRC.
+                // Go: wantFileCRC := uint32(br.ReadBits64(32))
+                let wantFileCRC = touint32(self.br.ReadBits64(32));
+                if !self.br.err.IsNil() {
+                    return (0, self.br.err.clone());
+                }
+                // Go: if bz2.fileCRC != wantFileCRC { … }
+                if self.fileCRC != wantFileCRC {
+                    self.br.err = structuralError("file checksum mismatch");
+                    return (0, self.br.err.clone());
+                }
+
+                // Skip ahead to byte boundary.
+                // Is there a file concatenated to this one?
+                // It would start with BZ.
+                // Go: if br.bits%8 != 0 { br.ReadBits(br.bits % 8) }
+                if self.br.bits % 8 != 0 {
+                    let odd = self.br.bits % 8;
+                    self.br.ReadBits(odd);
+                }
+                // Go: b, err := br.r.ReadByte()
+                let (b, err) = self.br.r.ReadByte();
+                if err == io::EOF {
+                    self.br.err = io::EOF.into();
+                    self.eof = true;
+                    return (0, io::EOF.into());
+                }
+                if !err.IsNil() {
+                    self.br.err = err.clone();
+                    return (0, err);
+                }
+                // Go: z, err := br.r.ReadByte()
+                let (z, err) = self.br.r.ReadByte();
+                if !err.IsNil() {
+                    // Go: if err == io.EOF { err = io.ErrUnexpectedEOF }
+                    let err = if err == io::EOF {
+                        io::ErrUnexpectedEOF.into()
+                    } else {
+                        err
+                    };
+                    self.br.err = err.clone();
+                    return (0, err);
+                }
+                // Go: if b != 'B' || z != 'Z' { … }
+                if b != b'B' || z != b'Z' {
+                    return (0, structuralError("bad magic value in continuation file"));
+                }
+                // Go: if err := bz2.setup(false); err != nil { return 0, err }
+                let err = self.setup(false);
+                if !err.IsNil() {
+                    return (0, err);
+                }
+            } else {
+                // Go: default: return 0, StructuralError("bad magic value found")
+                return (0, structuralError("bad magic value found"));
+            }
+        }
+    }
+
+    // go: sdk 1.25.5 compress/bzip2/bzip2.go:235-443 reader.readBlock
+    /// `(bz2 *reader).readBlock()` — read one bzip2 block. The magic
+    /// number should already have been consumed.
+    fn readBlock(&mut self) -> error {
+        // Go: br := &bz2.br — spelled inline; the block body writes
+        // `bz2.tt` and `bz2.c` while reading bits, so a live borrow of
+        // the field cannot span the function.
+
+        // Go: bz2.wantBlockCRC = uint32(br.ReadBits64(32))
+        // (skip checksum. TODO: check it if we can figure out what it is.)
+        self.wantBlockCRC = touint32(self.br.ReadBits64(32));
+        self.blockCRC = 0;
+        // Go: bz2.fileCRC = (bz2.fileCRC<<1 | bz2.fileCRC>>31) ^ bz2.wantBlockCRC
+        self.fileCRC = ((self.fileCRC << 1) | (self.fileCRC >> 31)) ^ self.wantBlockCRC;
+        // Go: randomized := br.ReadBits(1)
+        let randomized = self.br.ReadBits(1);
+        if randomized != 0 {
+            return structuralError("deprecated randomized files");
+        }
+        // Go: origPtr := uint(br.ReadBits(24))
+        let origPtr = touint(self.br.ReadBits(24));
+
+        // If not every byte value is used in the block (i.e., it's text) then
+        // the symbol set is reduced. The symbols used are stored as a
+        // two-level, 16x16 bitmap.
+        // Go: symbolRangeUsedBitmap := br.ReadBits(16)
+        let symbolRangeUsedBitmap = self.br.ReadBits(16);
+        // Go: symbolPresent := make([]bool, 256); numSymbols := 0
+        let mut symbolPresent = crate::make!([]bool, 256);
+        let mut numSymbols: int = 0;
+        // Go: for symRange := uint(0); symRange < 16; symRange++
+        let mut symRange: uint = 0;
+        while symRange < 16 {
+            if symbolRangeUsedBitmap & (1 << (15 - symRange)) != 0 {
+                // Go: bits := br.ReadBits(16)
+                let bits = self.br.ReadBits(16);
+                // Go: for symbol := uint(0); symbol < 16; symbol++
+                let mut symbol: uint = 0;
+                while symbol < 16 {
+                    if bits & (1 << (15 - symbol)) != 0 {
+                        symbolPresent[16 * symRange + symbol] = true;
+                        numSymbols += 1;
+                    }
+                    symbol += 1;
+                }
+            }
+            symRange += 1;
+        }
+
+        // Go: if numSymbols == 0 { return StructuralError("no symbols in input") }
+        if numSymbols == 0 {
+            // There must be an EOF symbol.
+            return structuralError("no symbols in input");
+        }
+
+        // A block uses between two and six different Huffman trees.
+        // Go: numHuffmanTrees := br.ReadBits(3)
+        let numHuffmanTrees = self.br.ReadBits(3);
+        if numHuffmanTrees < 2 || numHuffmanTrees > 6 {
+            return structuralError("invalid number of Huffman trees");
+        }
+
+        // The Huffman tree can switch every 50 symbols so there's a list of
+        // tree indexes telling us which tree to use for each 50 symbol block.
+        // Go: numSelectors := br.ReadBits(15); treeIndexes := make([]uint8, numSelectors)
+        let numSelectors = self.br.ReadBits(15);
+        let mut treeIndexes = crate::make!([]byte, numSelectors);
+
+        // The tree indexes are move-to-front transformed and stored as unary
+        // numbers.
+        // Go: mtfTreeDecoder := newMTFDecoderWithRange(numHuffmanTrees)
+        let mut mtfTreeDecoder = newMTFDecoderWithRange(numHuffmanTrees);
+        // Go: for i := range treeIndexes
+        for i in 0..treeIndexes.Len() {
+            // Go: c := 0; for { inc := br.ReadBits(1); if inc == 0 { break }; c++ }
+            let mut c: int = 0;
+            loop {
+                let inc = self.br.ReadBits(1);
+                if inc == 0 {
+                    break;
+                }
+                c += 1;
+            }
+            if c >= numHuffmanTrees {
+                return structuralError("tree index too large");
+            }
+            treeIndexes[i] = mtfTreeDecoder.Decode(c);
+        }
+
+        // The list of symbols for the move-to-front transform is taken from
+        // the previously decoded symbol bitmap.
+        // Go: symbols := make([]byte, numSymbols); nextSymbol := 0
+        let mut symbols = crate::make!([]byte, numSymbols);
+        let mut nextSymbol: int = 0;
+        // Go: for i := 0; i < 256; i++
+        let mut i: int = 0;
+        while i < 256 {
+            if symbolPresent[i] {
+                symbols[nextSymbol] = tobyte(i);
+                nextSymbol += 1;
+            }
+            i += 1;
+        }
+        // Go: mtf := newMTFDecoder(symbols)
+        let mut mtf = newMTFDecoder(symbols);
+
+        // Go: numSymbols += 2 // to account for RUNA and RUNB symbols
+        numSymbols += 2;
+        // Go: huffmanTrees := make([]huffmanTree, numHuffmanTrees)
+        let mut huffmanTrees = crate::make!([]huffmanTree, numHuffmanTrees);
+
+        // Now we decode the arrays of code-lengths for each tree.
+        // Go: lengths := make([]uint8, numSymbols)
+        let mut lengths = crate::make!([]byte, numSymbols);
+        // Go: for i := range huffmanTrees
+        for i in 0..huffmanTrees.Len() {
+            // The code lengths are delta encoded from a 5-bit base value.
+            // Go: length := br.ReadBits(5)
+            let mut length = self.br.ReadBits(5);
+            // Go: for j := range lengths
+            for j in 0..lengths.Len() {
+                loop {
+                    if length < 1 || length > 20 {
+                        return structuralError("Huffman length out of range");
+                    }
+                    if !self.br.ReadBit() {
+                        break;
+                    }
+                    if self.br.ReadBit() {
+                        length -= 1;
+                    } else {
+                        length += 1;
+                    }
+                }
+                lengths[j] = tobyte(length);
+            }
+            // Go: huffmanTrees[i], err = newHuffmanTree(lengths)
+            let (tree, err) = newHuffmanTree(&lengths);
+            huffmanTrees[i] = tree;
+            if !err.IsNil() {
+                return err;
+            }
+        }
+
+        // Go: selectorIndex := 1 // the next tree index to use
+        let mut selectorIndex: int = 1;
+        if treeIndexes.Len() == 0 {
+            return structuralError("no tree selectors given");
+        }
+        if toint(treeIndexes[0]) >= huffmanTrees.Len() {
+            return structuralError("tree selector out of range");
+        }
+        // Go: currentHuffmanTree := huffmanTrees[treeIndexes[0]]
+        //
+        // Go copies the tree struct (two words sharing one node table);
+        // goish holds the INDEX instead, because `slice<T>` clones its
+        // backing on assignment and this runs every 50 symbols.
+        let mut currentHuffmanTree: int = toint(treeIndexes[0]);
+        // Go: bufIndex := 0 // indexes bz2.buf, the output buffer.
+        let mut bufIndex: int = 0;
+        // The output of the move-to-front transform is run-length encoded and
+        // we merge the decoding into the Huffman parsing loop. These two
+        // variables accumulate the repeat count. See the Wikipedia page for
+        // details.
+        let mut repeat: int = 0;
+        let mut repeatPower: int = 0;
+
+        // The `C' array (used by the inverse BWT) needs to be zero initialized.
+        // Go: clear(bz2.c[:])
+        let mut k: int = 0;
+        while k < 256 {
+            self.c[k] = 0;
+            k += 1;
+        }
+
+        // Go: decoded := 0 // counts the number of symbols decoded by the current tree.
+        let mut decoded: int = 0;
+        loop {
+            // Go: if decoded == 50 { … }
+            if decoded == 50 {
+                if selectorIndex >= numSelectors {
+                    return structuralError(
+                        "insufficient selector indices for number of symbols",
+                    );
+                }
+                if toint(treeIndexes[selectorIndex]) >= huffmanTrees.Len() {
+                    return structuralError("tree selector out of range");
+                }
+                currentHuffmanTree = toint(treeIndexes[selectorIndex]);
+                selectorIndex += 1;
+                decoded = 0;
+            }
+
+            // Go: v := currentHuffmanTree.Decode(br); decoded++
+            let v = huffmanTrees[currentHuffmanTree].Decode(&mut self.br);
+            decoded += 1;
+
+            // Go: if v < 2 { … continue }
+            if v < 2 {
+                // This is either the RUNA or RUNB symbol.
+                if repeat == 0 {
+                    repeatPower = 1;
+                }
+                repeat += repeatPower << v;
+                repeatPower <<= 1;
+
+                // This limit of 2 million comes from the bzip2 source
+                // code. It prevents repeat from overflowing.
+                if repeat > 2 * 1024 * 1024 {
+                    return structuralError("repeat count too large");
+                }
+                continue;
+            }
+
+            // Go: if repeat > 0 { … }
+            if repeat > 0 {
+                // We have decoded a complete run-length so we need to
+                // replicate the last output symbol.
+                if repeat > self.blockSize - bufIndex {
+                    return structuralError("repeats past end of block");
+                }
+                // Go: for i := 0; i < repeat; i++
+                let mut i: int = 0;
+                while i < repeat {
+                    let b = mtf.First();
+                    self.tt[bufIndex] = touint32(b);
+                    self.c[b] += 1;
+                    bufIndex += 1;
+                    i += 1;
+                }
+                repeat = 0;
+            }
+
+            // Go: if int(v) == numSymbols-1 { break }
+            if toint(v) == numSymbols - 1 {
+                // This is the EOF symbol. Because it's always at the
+                // end of the move-to-front list, and never gets moved
+                // to the front, it has this unique value.
+                break;
+            }
+
+            // Since two metasymbols (RUNA and RUNB) have values 0 and 1,
+            // one would expect |v-2| to be passed to the MTF decoder.
+            // However, the front of the MTF list is never referenced as 0,
+            // it's always referenced with a run-length of 1. Thus 0
+            // doesn't need to be encoded and we have |v-1| in the next
+            // line.
+            // Go: b := mtf.Decode(int(v - 1))
+            let b = mtf.Decode(toint(v - 1));
+            if bufIndex >= self.blockSize {
+                return structuralError("data exceeds block size");
+            }
+            self.tt[bufIndex] = touint32(b);
+            self.c[b] += 1;
+            bufIndex += 1;
+        }
+
+        // Go: if origPtr >= uint(bufIndex) { … }
+        if origPtr >= touint(bufIndex) {
+            return structuralError("origPtr out of bounds");
+        }
+
+        // We have completed the entropy decoding. Now we can perform the
+        // inverse BWT and setup the RLE buffer.
+        // Go: bz2.preRLE = bz2.tt[:bufIndex]  — see the aliasing note in
+        // the file header; goish's subslice copies.
+        self.preRLE = self.tt.slice(0, bufIndex);
+        self.preRLEUsed = 0;
+        // Go: bz2.tPos = inverseBWT(bz2.preRLE, origPtr, bz2.c[:])
+        self.tPos = inverseBWT(&mut self.preRLE, origPtr, &mut self.c);
+        self.lastByte = -1;
+        self.byteRepeats = 0;
+        self.repeats = 0;
+
+        return nil;
+    }
+}
+
+// go: sdk 1.25.5 compress/bzip2/bzip2.go:446-469 inverseBWT
+/// `bzip2.inverseBWT(tt, origPtr, c)` — the inverse Burrows-Wheeler
+/// transform as described in
+/// <http://www.hpl.hp.com/techreports/Compaq-DEC/SRC-RR-124.pdf>,
+/// section 4.2. In that document, `origPtr` is called "I" and `c` is
+/// the "C" array after the first pass over the data. It's an argument
+/// here because we merge the first pass with the Huffman decoding.
+///
+/// This also implements the "single array" method from the bzip2 source
+/// code which leaves the output, still shuffled, in the bottom 8 bits of
+/// `tt` with the index of the next byte in the top 24 bits. The index of
+/// the first byte is returned.
+///
+/// `c` is `&mut array<uint, 256>`, not `slice<uint>`: Go passes
+/// `bz2.c[:]`, a mutable VIEW of the reader's array field, and goish's
+/// `to_slice()` would hand over a copy whose updates never landed. The
+/// borrow of the array is the goish spelling of that view.
+fn inverseBWT(tt: &mut slice<uint32>, origPtr: uint, c: &mut array<uint, 256>) -> uint32 {
+    // Go: sum := uint(0); for i := 0; i < 256; i++ { sum += c[i]; c[i] = sum - c[i] }
+    let mut sum: uint = 0;
+    let mut i: int = 0;
+    while i < 256 {
+        sum += c[i];
+        c[i] = sum - c[i];
+        i += 1;
+    }
+
+    // Go: for i := range tt { b := tt[i] & 0xff; tt[c[b]] |= uint32(i) << 8; c[b]++ }
+    for i in 0..tt.Len() {
+        let b = tt[i] & 0xff;
+        let cb = c[b];
+        tt[cb] |= touint32(i) << 8;
+        c[b] += 1;
+    }
+
+    // Go: return tt[origPtr] >> 8
+    return tt[origPtr] >> 8;
+}
+
+// This is a standard CRC32 like in hash/crc32 except that all the shifts are reversed,
+// causing the bits in the input to be processed in the reverse of the usual order.
+
+// go: sdk 1.25.5 compress/bzip2/bzip2.go:475-475 crctab
+/// `bzip2.crctab` — the reversed-CRC32 table. Go fills it from a
+/// package `init()`; goish evaluates it at compile time (see the file
+/// header).
+static crctab: array<uint32, 256> = array::__from_arr(crctabInit());
+
+// go: none — goish idiom: this is Go's package `init()` (bzip2.go:477),
+// which goish has no equivalent of. `port_coverage` excludes `init`
+// from the denominator, and an anchor named `init` would be ambiguous
+// across a package, so the table it fills carries the anchor instead.
+/// Go's package `init()` for [`crctab`], as a `const fn` so the table
+/// costs nothing at run time.
+const fn crctabInit() -> [uint32; 256] {
+    // Go: const poly = 0x04C11DB7
+    const poly: uint32 = 0x04C11DB7;
+    let mut tab = [0u32; 256];
+    // Go: for i := range crctab
+    let mut i: usize = 0;
+    while i < 256 {
+        // Go: crc := uint32(i) << 24
+        // (`as` is unavoidable here: goish's `uint32()` is not `const fn`.)
+        let mut crc: uint32 = (i as uint32) << 24;
+        // Go: for j := 0; j < 8; j++
+        let mut j = 0;
+        while j < 8 {
+            if crc & 0x80000000 != 0 {
+                crc = (crc << 1) ^ poly;
+            } else {
+                crc <<= 1;
+            }
+            j += 1;
+        }
+        // Go: crctab[i] = crc
+        tab[i] = crc;
+        i += 1;
+    }
+    tab
+}
+
+// go: sdk 1.25.5 compress/bzip2/bzip2.go:492-499 updateCRC
+/// `bzip2.updateCRC(val, b)` — fold `b` into the running CRC. The
+/// initial value is 0.
+fn updateCRC(val: uint32, b: &slice<byte>) -> uint32 {
+    // Go: crc := ^val
+    let mut crc: uint32 = !val;
+    // Go: for _, v := range b { crc = crctab[byte(crc>>24)^v] ^ (crc << 8) }
+    for (_, v) in crate::range!(b) {
+        crc = crctab[tobyte(crc >> 24) ^ *v] ^ (crc << 8);
+    }
+    // Go: return ^crc
+    return !crc;
+}
+
+// ─── trait impls ───────────────────────────────────────────────────────
+
+impl<R: io::Reader> io::Reader for reader<R> {
+    // go: none — goish idiom: Go's `reader` satisfies `io.Reader`
+    // structurally, by having the method. goish needs the `impl` block
+    // written out; the port itself is the inherent `Read` above.
+    fn Read(&mut self, p: &mut slice<byte>) -> (int, error) {
+        return reader::Read(self, p);
+    }
+}

--- a/src/compress/bzip2/huffman.rs
+++ b/src/compress/bzip2/huffman.rs
@@ -1,0 +1,336 @@
+// go: file compress/bzip2/huffman.go decls: huffmanTree, huffmanNode, invalidNodeValue, huffmanTree.Decode, newHuffmanTree, huffmanSymbolLengthPair, huffmanCode, buildHuffmanNode
+//
+// compress/bzip2/huffman.go — the canonical Huffman decoder.
+//
+// bzip2 transmits only the code LENGTH of each symbol; the codes
+// themselves are reconstructed canonically (sort by length, then by
+// symbol value, then assign increasing codes packed at the MSB end of
+// a uint32). Sorting the finished codes groups each branch's left half
+// together, which is what lets `buildHuffmanNode` split the list
+// recursively instead of walking bit-by-bit.
+//
+// Slim deviation:
+//   * Go's `Decode` holds `node := &t.nodes[nodeIndex]`, a pointer into
+//     the node table. goish copies the node (8 bytes, `Copy`) instead —
+//     the loop only ever reads it, and a live `&` into `t.nodes` would
+//     collide with nothing here but reads worse.
+
+#![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
+
+use crate::cmp;
+use crate::convert::uint16 as touint16;
+use crate::errors::{error, nil};
+use crate::goslice::slice;
+use crate::io::ByteReader;
+use crate::slices;
+use crate::types::{int, uint16, uint32, uint8};
+
+use super::bit_reader::bitReader;
+use super::bzip2::structuralError;
+
+// go: sdk 1.25.5 compress/bzip2/huffman.go:12-19 huffmanTree
+/// `bzip2.huffmanTree` — a binary tree navigated bit-by-bit to reach a
+/// symbol. `nodes[0]` is the root; `nextNode` is the bump allocator
+/// index used while the tree is under construction.
+#[derive(Clone, Default)]
+pub(super) struct huffmanTree {
+    // Go: nodes []huffmanNode
+    pub(super) nodes: slice<huffmanNode>,
+    // Go: nextNode int
+    pub(super) nextNode: int,
+}
+
+// go: sdk 1.25.5 compress/bzip2/huffman.go:22-31 huffmanNode
+/// `bzip2.huffmanNode` — one non-leaf node. `left`/`right` index into
+/// the tree's `nodes`; [`invalidNodeValue`] there marks a leaf whose
+/// symbol is in `leftValue`/`rightValue`.
+///
+/// The symbols are `uint16` because bzip2 encodes MTF indexes plus two
+/// run-length metasymbols and an EOF symbol — more than 256 in all.
+#[derive(Clone, Copy, Default)]
+pub(super) struct huffmanNode {
+    // Go: left, right uint16
+    pub(super) left: uint16,
+    pub(super) right: uint16,
+    // Go: leftValue, rightValue uint16
+    pub(super) leftValue: uint16,
+    pub(super) rightValue: uint16,
+}
+
+// go: sdk 1.25.5 compress/bzip2/huffman.go:34-35 invalidNodeValue
+/// `bzip2.invalidNodeValue` — an invalid index which marks a leaf node
+/// in the tree.
+pub(super) const invalidNodeValue: uint16 = 0xffff;
+
+impl huffmanTree {
+    // go: sdk 1.25.5 compress/bzip2/huffman.go:37-78 huffmanTree.Decode
+    /// `(t *huffmanTree).Decode(br)` — read bits from `br` and navigate
+    /// the tree until a symbol is found.
+    pub(super) fn Decode<R: ByteReader>(&self, br: &mut bitReader<R>) -> uint16 {
+        // Go: nodeIndex := uint16(0) // node 0 is the root of the tree.
+        let mut nodeIndex: uint16 = 0;
+
+        loop {
+            // Go: node := &t.nodes[nodeIndex]
+            let node = self.nodes[nodeIndex];
+
+            // Go: var bit uint16
+            let bit: uint16;
+            if br.bits > 0 {
+                // Get next bit - fast path.
+                // Go: br.bits--; bit = uint16(br.n>>(br.bits&63)) & 1
+                br.bits -= 1;
+                bit = touint16(br.n >> (br.bits & 63)) & 1;
+            } else {
+                // Get next bit - slow path.
+                // Use ReadBits to retrieve a single bit
+                // from the underling io.ByteReader.
+                // Go: bit = uint16(br.ReadBits(1))
+                bit = touint16(br.ReadBits(1));
+            }
+
+            // Trick a compiler into generating conditional move instead of branch,
+            // by making both loads unconditional.
+            // Go: l, r := node.left, node.right
+            let (l, r) = (node.left, node.right);
+
+            // Go: if bit == 1 { nodeIndex = l } else { nodeIndex = r }
+            if bit == 1 {
+                nodeIndex = l;
+            } else {
+                nodeIndex = r;
+            }
+
+            // Go: if nodeIndex == invalidNodeValue
+            if nodeIndex == invalidNodeValue {
+                // We found a leaf. Use the value of bit to decide
+                // whether is a left or a right value.
+                // Go: l, r := node.leftValue, node.rightValue
+                let (l, r) = (node.leftValue, node.rightValue);
+                if bit == 1 {
+                    return l;
+                }
+                return r;
+            }
+        }
+    }
+}
+
+// go: sdk 1.25.5 compress/bzip2/huffman.go:81-141 newHuffmanTree
+/// `bzip2.newHuffmanTree(lengths)` — build a tree from the code length
+/// of each symbol. The maximum code length is 32 bits.
+pub(super) fn newHuffmanTree(lengths: &slice<uint8>) -> (huffmanTree, error) {
+    // There are many possible trees that assign the same code length to
+    // each symbol (consider reflecting a tree down the middle, for
+    // example). Since the code length assignments determine the
+    // efficiency of the tree, each of these trees is equally good. In
+    // order to minimize the amount of information needed to build a tree
+    // bzip2 uses a canonical tree so that it can be reconstructed given
+    // only the code length assignments.
+
+    // Go: if len(lengths) < 2 { panic("newHuffmanTree: too few symbols") }
+    if lengths.Len() < 2 {
+        panic!("newHuffmanTree: too few symbols");
+    }
+
+    // Go: var t huffmanTree
+    let mut t = huffmanTree::default();
+
+    // First we sort the code length assignments by ascending code length,
+    // using the symbol value to break ties.
+    // Go: pairs := make([]huffmanSymbolLengthPair, len(lengths))
+    let mut pairs = crate::make!([]huffmanSymbolLengthPair, lengths.Len());
+    // Go: for i, length := range lengths
+    for (i, length) in crate::range!(lengths) {
+        pairs[i].value = touint16(i);
+        pairs[i].length = *length;
+    }
+
+    // Go: slices.SortFunc(pairs, func(a, b huffmanSymbolLengthPair) int { … })
+    slices::SortFunc!(pairs, |a: &huffmanSymbolLengthPair, b: &huffmanSymbolLengthPair| {
+        let c = cmp::Compare(&a.length, &b.length);
+        if c != 0 {
+            return c;
+        }
+        return cmp::Compare(&a.value, &b.value);
+    });
+
+    // Now we assign codes to the symbols, starting with the longest code.
+    // We keep the codes packed into a uint32, at the most-significant end.
+    // So branches are taken from the MSB downwards. This makes it easy to
+    // sort them later.
+    // Go: code := uint32(0); length := uint8(32)
+    let mut code: uint32 = 0;
+    let mut length: uint8 = 32;
+
+    // Go: codes := make([]huffmanCode, len(lengths))
+    let mut codes = crate::make!([]huffmanCode, lengths.Len());
+    // Go: for i := len(pairs) - 1; i >= 0; i--
+    let mut i = pairs.Len() - 1;
+    while i >= 0 {
+        if length > pairs[i].length {
+            length = pairs[i].length;
+        }
+        codes[i].code = code;
+        codes[i].codeLen = length;
+        codes[i].value = pairs[i].value;
+        // We need to 'increment' the code, which means treating |code|
+        // like a |length| bit number.
+        //
+        // Go: code += 1 << (32 - length)
+        //
+        // `length` is at least 1 here (readBlock rejects 0), so the
+        // shift is at most 31 and cannot reach Rust's overflow panic.
+        // The add wraps: Go's uint32 arithmetic does, and a code list
+        // whose Kraft sum exceeds 1 relies on it.
+        code = code.wrapping_add(1u32 << (32 - length));
+        i -= 1;
+    }
+
+    // Now we can sort by the code so that the left half of each branch are
+    // grouped together, recursively.
+    // Go: slices.SortFunc(codes, func(a, b huffmanCode) int { return cmp.Compare(a.code, b.code) })
+    slices::SortFunc!(codes, |a: &huffmanCode, b: &huffmanCode| {
+        return cmp::Compare(&a.code, &b.code);
+    });
+
+    // Go: t.nodes = make([]huffmanNode, len(codes))
+    t.nodes = crate::make!([]huffmanNode, codes.Len());
+    // Go: _, err := buildHuffmanNode(&t, codes, 0); return t, err
+    let (_, err) = buildHuffmanNode(&mut t, &codes, 0);
+    return (t, err);
+}
+
+// go: sdk 1.25.5 compress/bzip2/huffman.go:144-147 huffmanSymbolLengthPair
+/// `bzip2.huffmanSymbolLengthPair` — a symbol and its code length.
+#[derive(Clone, Copy, Default)]
+pub(super) struct huffmanSymbolLengthPair {
+    // Go: value uint16
+    pub(super) value: uint16,
+    // Go: length uint8
+    pub(super) length: uint8,
+}
+
+// go: sdk 1.25.5 compress/bzip2/huffman.go:150-154 huffmanCode
+/// `bzip2.huffmanCode` — a symbol, its code and code length.
+#[derive(Clone, Copy, Default)]
+pub(super) struct huffmanCode {
+    // Go: code uint32
+    pub(super) code: uint32,
+    // Go: codeLen uint8
+    pub(super) codeLen: uint8,
+    // Go: value uint16
+    pub(super) value: uint16,
+}
+
+// go: sdk 1.25.5 compress/bzip2/huffman.go:157-233 buildHuffmanNode
+/// `bzip2.buildHuffmanNode(t, codes, level)` — build the node of `t` at
+/// `level` from a code-sorted slice, returning its index in `t.nodes`.
+pub(super) fn buildHuffmanNode(
+    t: &mut huffmanTree,
+    codes: &slice<huffmanCode>,
+    level: uint32,
+) -> (uint16, error) {
+    // Go: test := uint32(1) << (31 - level)
+    //
+    // Go neither panics on the `31 - level` underflow nor on a shift
+    // count >= 32 — the first wraps, the second yields 0. Rust panics
+    // on both, so spell them out. `level` is bounded by 31 for every
+    // length vector readBlock admits (lengths <= 20 make all codes a
+    // multiple of 2^12, so the low 12 levels always take the
+    // superfluous-level arm below and hit its `level == 31` guard);
+    // this arm is what keeps a future caller from turning that
+    // reasoning into an abort on hostile input.
+    let shift = 31u32.wrapping_sub(level);
+    let test: uint32 = if shift >= 32 { 0 } else { 1u32 << shift };
+
+    // We have to search the list of codes to find the divide between the left and right sides.
+    // Go: firstRightIndex := len(codes)
+    let mut firstRightIndex = codes.Len();
+    // Go: for i, code := range codes
+    for (i, code) in crate::range!(codes) {
+        if code.code & test != 0 {
+            firstRightIndex = i;
+            break;
+        }
+    }
+
+    // Go: left := codes[:firstRightIndex]; right := codes[firstRightIndex:]
+    let left = codes.slice(0, firstRightIndex);
+    let right = codes.slice(firstRightIndex, codes.Len());
+
+    // Go: if len(left) == 0 || len(right) == 0
+    if left.Len() == 0 || right.Len() == 0 {
+        // There is a superfluous level in the Huffman tree indicating
+        // a bug in the encoder. However, this bug has been observed in
+        // the wild so we handle it.
+
+        // If this function was called recursively then we know that
+        // len(codes) >= 2 because, otherwise, we would have hit the
+        // "leaf node" case, below, and not recurred.
+        //
+        // However, for the initial call it's possible that len(codes)
+        // is zero or one. Both cases are invalid because a zero length
+        // tree cannot encode anything and a length-1 tree can only
+        // encode EOF and so is superfluous. We reject both.
+        if codes.Len() < 2 {
+            return (0, structuralError("empty Huffman tree"));
+        }
+
+        // In this case the recursion doesn't always reduce the length
+        // of codes so we need to ensure termination via another
+        // mechanism.
+        if level == 31 {
+            // Since len(codes) >= 2 the only way that the values
+            // can match at all 32 bits is if they are equal, which
+            // is invalid. This ensures that we never enter
+            // infinite recursion.
+            return (0, structuralError("equal symbols in Huffman tree"));
+        }
+
+        if left.Len() == 0 {
+            return buildHuffmanNode(t, &right, level + 1);
+        }
+        return buildHuffmanNode(t, &left, level + 1);
+    }
+
+    // Go: nodeIndex = uint16(t.nextNode); node := &t.nodes[t.nextNode]; t.nextNode++
+    let nodeIndex: uint16 = touint16(t.nextNode);
+    let node = t.nextNode;
+    t.nextNode += 1;
+
+    // Go's named return `err` starts nil and is assigned by each half.
+    let mut err: error = nil;
+
+    // Go: if len(left) == 1 { node.left = invalidNodeValue; node.leftValue = left[0].value }
+    //     else { node.left, err = buildHuffmanNode(t, left, level+1) }
+    if left.Len() == 1 {
+        // leaf node
+        t.nodes[node].left = invalidNodeValue;
+        t.nodes[node].leftValue = left[0].value;
+    } else {
+        let (v, e) = buildHuffmanNode(t, &left, level + 1);
+        t.nodes[node].left = v;
+        err = e;
+    }
+
+    // Go: if err != nil { return }
+    if !err.IsNil() {
+        return (nodeIndex, err);
+    }
+
+    // Go: if len(right) == 1 { node.right = invalidNodeValue; node.rightValue = right[0].value }
+    //     else { node.right, err = buildHuffmanNode(t, right, level+1) }
+    if right.Len() == 1 {
+        // leaf node
+        t.nodes[node].right = invalidNodeValue;
+        t.nodes[node].rightValue = right[0].value;
+    } else {
+        let (v, e) = buildHuffmanNode(t, &right, level + 1);
+        t.nodes[node].right = v;
+        err = e;
+    }
+
+    // Go: return
+    return (nodeIndex, err);
+}

--- a/src/compress/bzip2/mod.rs
+++ b/src/compress/bzip2/mod.rs
@@ -1,0 +1,26 @@
+// go: package compress/bzip2
+//
+// compress/bzip2 — bzip2 decompression.
+//
+// One Rust file per Go file, so each can carry its own provenance
+// anchors (GOISH015 forbids two Go files in one Rust file, and an
+// unanchored file is invisible to the fidelity tier):
+//
+//   bit_reader.rs     bit_reader.go      — MSB-first bit reader
+//   bzip2.rs          bzip2.go           — the reader, RLE1, inverse BWT
+//   huffman.rs        huffman.go         — canonical Huffman decoder
+//   move_to_front.rs  move_to_front.go   — the MTF list
+//
+// Decompression only. Go's `compress/bzip2` has no compressor either,
+// so this is the whole package, not a slice of it.
+//
+// This file is a module root, so it carries no `// go:` anchors.
+
+#![allow(non_snake_case, non_camel_case_types)]
+
+pub mod bit_reader;
+pub mod bzip2;
+pub mod huffman;
+pub mod move_to_front;
+
+pub use bzip2::{reader, NewReader, StructuralError};

--- a/src/compress/bzip2/move_to_front.rs
+++ b/src/compress/bzip2/move_to_front.rs
@@ -1,0 +1,94 @@
+// go: file compress/bzip2/move_to_front.go decls: moveToFrontDecoder, newMTFDecoder, newMTFDecoderWithRange, moveToFrontDecoder.Decode, moveToFrontDecoder.First
+//
+// compress/bzip2/move_to_front.go — the move-to-front list.
+//
+// bzip2 runs MTF twice per block: once over the symbol alphabet (so a
+// repeated byte encodes as a run of zeros, which the RLE2 stage then
+// collapses), and once over the Huffman tree selectors.
+//
+// Slim deviation:
+//   * Go's `moveToFrontDecoder` is `[]byte`, so its methods take a
+//     VALUE receiver and still mutate the caller's list — the slice
+//     header is copied, the backing array is shared. goish's
+//     `slice<byte>` copies on subslice (goslice.rs:17), so the
+//     mutation has to be spelled as `&mut self`. The type stays a
+//     newtype over `slice<byte>` to keep Go's shape.
+
+#![allow(non_snake_case, non_camel_case_types)]
+
+use crate::convert::byte as tobyte;
+use crate::goslice::slice;
+use crate::types::{byte, int};
+
+// go: sdk 1.25.5 compress/bzip2/move_to_front.go:7-14 moveToFrontDecoder
+/// `bzip2.moveToFrontDecoder` — a move-to-front list. Symbols are
+/// referenced by their index into the list, and a referenced symbol
+/// moves to the front, so a repeated symbol encodes as a run of zeros.
+pub struct moveToFrontDecoder(pub(super) slice<byte>);
+
+// go: sdk 1.25.5 compress/bzip2/move_to_front.go:16-22 newMTFDecoder
+/// `bzip2.newMTFDecoder(symbols)` — a decoder with an explicit initial
+/// list of symbols. Panics above 256 symbols, as Go does.
+pub fn newMTFDecoder(symbols: slice<byte>) -> moveToFrontDecoder {
+    // Go: if len(symbols) > 256 { panic("too many symbols") }
+    if symbols.Len() > 256 {
+        panic!("too many symbols");
+    }
+    // Go: return moveToFrontDecoder(symbols)
+    return moveToFrontDecoder(symbols);
+}
+
+// go: sdk 1.25.5 compress/bzip2/move_to_front.go:25-36 newMTFDecoderWithRange
+/// `bzip2.newMTFDecoderWithRange(n)` — a decoder whose initial list is
+/// `0...n-1`. Used for the Huffman tree selectors.
+pub fn newMTFDecoderWithRange(n: int) -> moveToFrontDecoder {
+    // Go: if n > 256 { panic("newMTFDecoderWithRange: cannot have > 256 symbols") }
+    if n > 256 {
+        panic!("newMTFDecoderWithRange: cannot have > 256 symbols");
+    }
+
+    // Go: m := make([]byte, n); for i := 0; i < n; i++ { m[i] = byte(i) }
+    let mut m = crate::make!([]byte, n);
+    let mut i: int = 0;
+    while i < n {
+        m[i] = tobyte(i);
+        i += 1;
+    }
+    // Go: return moveToFrontDecoder(m)
+    return moveToFrontDecoder(m);
+}
+
+impl moveToFrontDecoder {
+    // go: sdk 1.25.5 compress/bzip2/move_to_front.go:39-47 moveToFrontDecoder.Decode
+    /// `(m moveToFrontDecoder).Decode(n)` — the symbol at index `n`,
+    /// moved to the front of the list.
+    pub fn Decode(&mut self, n: int) -> byte {
+        // Implement move-to-front with a simple copy. This approach
+        // beats more sophisticated approaches in benchmarking, probably
+        // because it has high locality of reference inside of a
+        // single cache line (most move-to-front operations have n < 64).
+        //
+        // Go: b = m[n]; copy(m[1:], m[:n]); m[0] = b
+        //
+        // Go's `copy` there is a memmove within ONE backing array;
+        // `copy!(dst, src)` cannot express that (both handles would
+        // have to borrow `self.0`), and goish's `slice()` copies, so
+        // the shift is written out. Same element moves, same order.
+        let b = self.0[n];
+        let mut i = n;
+        while i > 0 {
+            self.0[i] = self.0[i - 1];
+            i -= 1;
+        }
+        self.0[0] = b;
+        return b;
+    }
+
+    // go: sdk 1.25.5 compress/bzip2/move_to_front.go:50-52 moveToFrontDecoder.First
+    /// `(m moveToFrontDecoder).First()` — the symbol at the front of
+    /// the list, without moving anything. The RLE2 stage replays it.
+    pub fn First(&self) -> byte {
+        // Go: return m[0]
+        return self.0[0];
+    }
+}

--- a/src/compress/mod.rs
+++ b/src/compress/mod.rs
@@ -1,11 +1,13 @@
 // compress — Go's `compress` parent package.
 //
 // Submodules:
+//   * `bzip2` — bzip2 decompression.
 //   * `flate` — DEFLATE compressed data format (RFC 1951).
 //   * `gzip`  — gzip file format (RFC 1952).
 //   * `lzw`   — Lempel-Ziv-Welch (GIF/PDF flavor).
 //   * `zlib`  — zlib compressed data format (RFC 1950).
 
+pub mod bzip2;
 pub mod flate;
 pub mod gzip;
 pub mod lzw;


### PR DESCRIPTION
compress/bzip2 was 0/20. It is now 20/20 by name and 21/21 by declaration, with all four Go files split one-to-one into Rust files so each can carry anchors: 34 `sdk` anchors, 3 `go: none` markers, 5 file manifests. `anchor_check.py` resolves 34/34.

That makes it the first anchored package in `compress/`. The other four (flate, gzip, lzw, zlib) hold 122 name-level ports and zero anchors between them, which is the split PROGRESS.md now uses `compress` to illustrate — same subtree, same percentage column, two different claims.

Verification came from a running Go, not from transcription (AGENTS.md §10). The four Go 1.25.5 sources are byte-identical to the 1.26.5 tree on this host, so the cited ranges hold. examples/bzip2_smoke.rs runs Go's own TestReader / TestBitReader / TestMTF / TestZeroRead vectors, 12/12 green, and checks the three failure vectors by exact MESSAGE:

  out-of-range selector (issue 8363) -> "unexpected EOF"
  bad block size (issue 13941)       -> "repeats past end of block"
  bad huffman delta                  -> "Huffman length out of range"

Collapsing any two of those would still "fail correctly" and be wrong. The first is the sharpest: it must surface the bit reader's LATCHED io.ErrUnexpectedEOF, not a structural complaint about the zeros a failed read handed back.

The seven testdata corpora an example cannot embed were run out of band, comparing length + FNV-1a/64 against Go: Isaac.Newton-Opticks (567 KB — many blocks, tree switching every 50 symbols across several selectors), random.data (the full 256-symbol alphabet), e.txt, pass-random1/2, the 1 MiB sawtooth, and fail-issue5747 (the RLE2 buffer overrun). All byte-identical to Go; the overrun rejected with Go's message. Results recorded in the example's header.

Deviations, each documented where it occurs:

  * newBitReader wraps in bufio unconditionally. Go does `r.(io.ByteReader)` first; goish has no runtime type assertion on a concrete generic (AGENTS.md §9b). flate and lzw made the same choice. Go's NewReader doc already warns a non-ByteReader source "may read more data than necessary" — that is the whole difference.

  * `preRLE = tt[:bufIndex]` copies rather than aliases (goslice.rs:17). Observationally identical: tt is scratch, rewritten from index 0 by the next readBlock, and nothing reads it in between.

  * currentHuffmanTree is an INDEX, not Go's struct copy. Go copies two words sharing one node table; goish's slice<T> clones its backing, and this runs every 50 symbols.

  * crctab is a const fn table, not Go's package init(). No lock, no lazy slot, no startup work. port_coverage excludes init from the denominator, so the table carries the anchor and the fn is go: none.

  * moveToFrontDecoder.Decode takes &mut self. Go's []byte value receiver still mutates the caller's list through the shared backing array; goish's copies, so the mutation has to be spelled.

Two shift sites spell out Go's unmasked-shift semantics — `1 << bits` at bits >= 64, and `1 << (31 - level)` when 31 - level underflows. Go yields 0 for both; Rust panics. level > 31 is in fact unreachable (readBlock's 1..20 length check makes every code a multiple of 2^12, so the low 12 levels always take the superfluous-level arm and hit its `level == 31` guard), but this decoder eats untrusted input and an abort is a worse failure mode than Go's.

NOT RUN: `make lint`. goishlint is not installed in this checkout and there is no sibling build, so the fidelity tier gated nothing here — a new file has to be lint-clean, and only CI can say whether these are. cargo check --lib and cargo build --examples are warning-free.

README and PROGRESS.md: compress 122/151 -> 142/151, 0 -> 42 `// go:` lines, whole-tree 4432 -> 4452 and 88 -> 89 packages at 100%. The README's declared-example count was stale at 417 before this; it is 419.