### PR TITLE
Port syscall.Openat for fswatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -926,6 +926,10 @@ name = "syscall_fswatch_smoke"
 path = "examples/syscall_fswatch_smoke.rs"
 
 [[example]]
+name = "syscall_openat_ref_smoke"
+path = "examples/syscall_openat_ref_smoke.rs"
+
+[[example]]
 name = "xxh3_smoke"
 path = "examples/xxh3_smoke.rs"
 

--- a/examples/syscall_openat_ref.txt
+++ b/examples/syscall_openat_ref.txt
@@ -1,0 +1,9 @@
+constants	65536	256	131072	2048	524288
+root	true	true
+child	true	true	true
+file-directory	true	true
+nofollow-directory	true	20
+missing	true	true
+embedded-nul	true	true
+closed-dirfd	true	true
+absolute-ignores-dirfd	true	true

--- a/examples/syscall_openat_ref_smoke.rs
+++ b/examples/syscall_openat_ref_smoke.rs
@@ -1,0 +1,129 @@
+// syscall_openat_ref_smoke — Linux openat behavior required by
+// typescript-go internal/fswatch/walkdir_unix.go.
+//
+// Reference: Go 1.25.5 syscall, measured by
+// tools/gen_syscall_openat_ref.go on linux/amd64. GO is verbatim output.
+
+#![no_std]
+#![no_main]
+#![allow(non_snake_case)]
+
+extern crate alloc;
+extern crate goish;
+
+use goish::{fmt, int, int32, nil, os, string, strings, syscall};
+
+const GO: &str = include_str!("syscall_openat_ref.txt");
+
+#[goish::main]
+fn main() {
+    let root = string::from_static("/tmp/goish_openat_ref");
+    let _ = os::Remove(root.clone() + "/link");
+    let _ = os::RemoveAll(root.clone());
+    let setupDirError = os::MkdirAll(root.clone() + "/sub", 0o755);
+    let setupFileError = os::WriteFile(root.clone() + "/file", b"x", 0o644);
+    // A directory target makes the no-follow row kill a mutation that silently
+    // drops O_NOFOLLOW: following this link would otherwise make Openat pass.
+    let setupLinkError = os::Symlink("sub", root.clone() + "/link");
+    if setupDirError != nil || setupFileError != nil || setupLinkError != nil {
+        syscall::Exit(1);
+    }
+
+    let flags = int(syscall::O_RDONLY
+        | syscall::O_CLOEXEC
+        | syscall::O_DIRECTORY
+        | syscall::O_NOCTTY
+        | syscall::O_NONBLOCK
+        | syscall::O_NOFOLLOW);
+    let mut out = strings::Builder::new();
+    let _ = fmt::Fprintf!(
+        &mut out,
+        "constants\t%d\t%d\t%d\t%d\t%d\n",
+        syscall::O_DIRECTORY,
+        syscall::O_NOCTTY,
+        syscall::O_NOFOLLOW,
+        syscall::O_NONBLOCK,
+        syscall::O_CLOEXEC
+    );
+
+    let (rootFD, rootError) = syscall::Openat(int(syscall::AT_FDCWD), root.clone(), flags, 0);
+    let _ = fmt::Fprintf!(&mut out, "root\t%t\t%t\n", rootFD >= 0, rootError == nil);
+
+    let (childFD, childError) = syscall::Openat(rootFD, "sub", flags, 0);
+    let mut stat = syscall::Stat_t::default();
+    let statError = syscall::Fstat(int32(childFD), &mut stat);
+    let _ = fmt::Fprintf!(
+        &mut out,
+        "child\t%t\t%t\t%t\n",
+        childFD >= 0,
+        childError == nil,
+        statError == 0 && stat.st_mode & syscall::S_IFMT == syscall::S_IFDIR
+    );
+    let _ = syscall::Close(int32(childFD));
+
+    let (fileFD, fileError) = syscall::Openat(rootFD, "file", flags, 0);
+    let _ = fmt::Fprintf!(
+        &mut out,
+        "file-directory\t%t\t%t\n",
+        fileFD == -1,
+        fileError == syscall::ENOTDIR
+    );
+
+    let (linkFD, linkError) = syscall::Openat(rootFD, "link", flags, 0);
+    let linkErrno = if linkError == syscall::ENOTDIR { 20 } else { 0 };
+    let _ = fmt::Fprintf!(
+        &mut out,
+        "nofollow-directory\t%t\t%d\n",
+        linkFD == -1,
+        linkErrno
+    );
+
+    let (missingFD, missingError) = syscall::Openat(rootFD, "missing", flags, 0);
+    let _ = fmt::Fprintf!(
+        &mut out,
+        "missing\t%t\t%t\n",
+        missingFD == -1,
+        missingError == syscall::ENOENT
+    );
+
+    let (nulFD, nulError) = syscall::Openat(rootFD, "sub\0ignored", flags, 0);
+    let _ = fmt::Fprintf!(
+        &mut out,
+        "embedded-nul\t%t\t%t\n",
+        nulFD == 0,
+        nulError == syscall::EINVAL
+    );
+
+    let _ = syscall::Close(int32(rootFD));
+    let (closedFD, closedError) = syscall::Openat(rootFD, "sub", flags, 0);
+    let _ = fmt::Fprintf!(
+        &mut out,
+        "closed-dirfd\t%t\t%t\n",
+        closedFD == -1,
+        closedError == syscall::Errno(9)
+    );
+
+    let (absoluteFD, absoluteError) = syscall::Openat(-1, root.clone() + "/sub", flags, 0);
+    let _ = fmt::Fprintf!(
+        &mut out,
+        "absolute-ignores-dirfd\t%t\t%t\n",
+        absoluteFD >= 0,
+        absoluteError == nil
+    );
+    let _ = syscall::Close(int32(absoluteFD));
+
+    let got = out.String();
+    let _ = os::Remove(root.clone() + "/link");
+    let _ = os::RemoveAll(root);
+    if got != GO {
+        syscall::Write(
+            syscall::STDERR,
+            got.as_bytes().as_ptr(),
+            got.as_bytes().len(),
+        );
+        syscall::Exit(1);
+    }
+    let message = b"SYSCALL_OPENAT_REF_OK Go 1.25.5 transcript matched\n";
+    syscall::Write(syscall::STDOUT, message.as_ptr(), message.len());
+    syscall::Exit(0);
+}

--- a/src/syscall/mod.rs
+++ b/src/syscall/mod.rs
@@ -24,7 +24,9 @@
 // carries 100 of them, all verified.
 //
 // This note exists because the unanchored-declaration scan reports
-// these 54 every time it is run. They are not a gap.
+// these 54 every time it is run. They are not a gap. Openat is the exception:
+// it was added later with the exact Go-shaped string/(fd,error) contract and
+// therefore carries its SDK anchor at the declaration.
 //
 // Calling convention (SysV / Linux x86-64 syscall):
 //   rax = syscall number
@@ -89,6 +91,7 @@ pub const SYS_EXECVE: usize = 59;
 pub const SYS_WAIT4: usize = 61;
 pub const SYS_DUP2: usize = 33;
 pub const SYS_DUP3: usize = 292;
+pub const SYS_OPENAT: usize = 257;
 
 // Signal numbers (Linux). Mirror /usr/include/asm-generic/signal.h.
 pub const SIGHUP: i32 = 1;
@@ -634,6 +637,12 @@ pub const EOPNOTSUPP: Errno = Errno(95);
 /// Open flags. Subset of `<fcntl.h>`.
 pub const O_RDONLY: i32 = 0;
 pub const O_CLOEXEC: i32 = 0o2_000_000;
+// go: sdk 1.25.5 syscall/zerrors_linux_amd64.go:626 O_DIRECTORY
+pub const O_DIRECTORY: i32 = 0o200_000;
+// go: sdk 1.25.5 syscall/zerrors_linux_amd64.go:633 O_NOCTTY
+pub const O_NOCTTY: i32 = 0o400;
+// go: sdk 1.25.5 syscall/zerrors_linux_amd64.go:634 O_NOFOLLOW
+pub const O_NOFOLLOW: i32 = 0o400_000;
 /// `O_PATH` — obtain an fd that references a location without opening
 /// the file itself (follows symlinks; needs only search permission).
 pub const O_PATH: i32 = 0o10_000_000;
@@ -643,6 +652,40 @@ pub const O_PATH: i32 = 0o10_000_000;
 #[allow(non_snake_case)]
 pub fn Open(path: *const u8, flags: i32, mode: i32) -> i32 {
     unsafe { syscall3(SYS_OPEN, path as usize, flags as usize, mode as usize) as i32 }
+}
+
+// go: sdk 1.25.5 syscall/syscall_linux.go:285-287 Openat
+// Go: func Openat(dirfd int, path string, flags int, mode uint32) (fd int, err error)
+/// `syscall.Openat(dirfd, path, flags, mode)` — open `path` relative to
+/// `dirfd`, or relative to the current directory for `AT_FDCWD`. Absolute
+/// paths ignore `dirfd`, as Linux specifies. Kernel failures return
+/// `(-1, error)`; an embedded NUL returns `(0, EINVAL)` before the syscall,
+/// matching Go's named-result zero value.
+#[allow(non_snake_case)]
+pub fn Openat<P: Into<crate::string>>(
+    dirfd: crate::int,
+    path: P,
+    flags: crate::int,
+    mode: u32,
+) -> (crate::int, crate::error) {
+    let path = path.into();
+    if path.as_bytes().contains(&0) {
+        return (0, EINVAL.into());
+    }
+    let path = __c_path(path);
+    let rc = unsafe {
+        syscall4(
+            SYS_OPENAT,
+            dirfd as usize,
+            path.as_ptr() as usize,
+            flags as usize,
+            mode as usize,
+        )
+    };
+    if rc < 0 {
+        return (-1, Errno(-crate::int32(rc)).into());
+    }
+    return (crate::int(rc), crate::errors::nil);
 }
 
 /// `close(2)` — close a file descriptor.

--- a/tools/gen_syscall_openat_ref.go
+++ b/tools/gen_syscall_openat_ref.go
@@ -1,0 +1,69 @@
+// Command gen_syscall_openat_ref records Linux syscall.Openat behavior used by
+// examples/syscall_openat_ref_smoke.rs. Run with Go 1.25.5 on linux/amd64.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func main() {
+	const atFDCWD = -100
+	root := "/tmp/goish_openat_ref"
+	_ = os.RemoveAll(root)
+	if err := os.MkdirAll(root+"/sub", 0o755); err != nil {
+		panic(err)
+	}
+	if err := os.WriteFile(root+"/file", []byte("x"), 0o644); err != nil {
+		panic(err)
+	}
+	// A directory target distinguishes O_NOFOLLOW from silently following the
+	// link: without O_NOFOLLOW, O_DIRECTORY would make this Openat succeed.
+	if err := os.Symlink("sub", root+"/link"); err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(root)
+
+	flags := syscall.O_RDONLY | syscall.O_CLOEXEC | syscall.O_DIRECTORY |
+		syscall.O_NOCTTY | syscall.O_NONBLOCK | syscall.O_NOFOLLOW
+	fmt.Printf("constants\t%d\t%d\t%d\t%d\t%d\n", syscall.O_DIRECTORY, syscall.O_NOCTTY, syscall.O_NOFOLLOW, syscall.O_NONBLOCK, syscall.O_CLOEXEC)
+
+	rootFD, err := syscall.Openat(atFDCWD, root, flags, 0)
+	fmt.Printf("root\t%t\t%t\n", rootFD >= 0, err == nil)
+
+	childFD, childErr := syscall.Openat(rootFD, "sub", flags, 0)
+	var stat syscall.Stat_t
+	statErr := syscall.Fstat(childFD, &stat)
+	fmt.Printf("child\t%t\t%t\t%t\n", childFD >= 0, childErr == nil, statErr == nil && stat.Mode&syscall.S_IFMT == syscall.S_IFDIR)
+	_ = syscall.Close(childFD)
+
+	fileFD, fileErr := syscall.Openat(rootFD, "file", flags, 0)
+	fmt.Printf("file-directory\t%t\t%t\n", fileFD == -1, errors.Is(fileErr, syscall.ENOTDIR))
+
+	linkFD, linkErr := syscall.Openat(rootFD, "link", flags, 0)
+	fmt.Printf("nofollow-directory\t%t\t%d\n", linkFD == -1, errnoNumber(linkErr))
+
+	missingFD, missingErr := syscall.Openat(rootFD, "missing", flags, 0)
+	fmt.Printf("missing\t%t\t%t\n", missingFD == -1, errors.Is(missingErr, syscall.ENOENT))
+
+	nulFD, nulErr := syscall.Openat(rootFD, "sub\x00ignored", flags, 0)
+	fmt.Printf("embedded-nul\t%t\t%t\n", nulFD == 0, errors.Is(nulErr, syscall.EINVAL))
+
+	_ = syscall.Close(rootFD)
+	closedFD, closedErr := syscall.Openat(rootFD, "sub", flags, 0)
+	fmt.Printf("closed-dirfd\t%t\t%t\n", closedFD == -1, errors.Is(closedErr, syscall.EBADF))
+
+	absFD, absErr := syscall.Openat(-1, root+"/sub", flags, 0)
+	fmt.Printf("absolute-ignores-dirfd\t%t\t%t\n", absFD >= 0, absErr == nil)
+	_ = syscall.Close(absFD)
+}
+
+func errnoNumber(err error) uintptr {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return uintptr(errno)
+	}
+	return 0
+}


### PR DESCRIPTION
## Summary

- add the Go-shaped `syscall.Openat` API needed by `typescript-go/internal/fswatch/walkdir_unix.go`
- add Linux/amd64 `O_DIRECTORY`, `O_NOCTTY`, and `O_NOFOLLOW`
- preserve Go 1.25.5's embedded-NUL behavior: pre-syscall `(0, EINVAL)` rather than a truncated kernel path
- add a Go-generated differential transcript and no-std smoke example

## Source anchors

- Go 1.25.5 `syscall/syscall_linux.go:285-287` (`Openat`)
- Go 1.25.5 `syscall/zerrors_linux_amd64.go:626,633,634` (flags)

## Validation

- exact Go 1.25.5 generator/transcript diff: clean
- `make e2e FILTER='^syscall_openat_ref_smoke$'`: 1/1, all green
- full `make e2e`: new `syscall_openat_ref_smoke` 1/1 and existing `syscall_fswatch_smoke` 50/50 across 4,329 total iterations
- full-suite outliers were unrelated: the intentional panic demo plus load/debug-profile-sensitive examples; every non-demo outlier passed its focused rerun (`http_hammer` 5,000/5,000, benchmark 8/8, runtime frames 5/5, testing callsites 6/6)
- `GOROOT=/usr/local/go SCOPE=src/syscall make lint`: no new finding
- scoped `rustfmt`, `gofmt`, and `git diff --check`: clean
- mutation probes killed 4/4: dropped `O_NOFOLLOW`, ignored `dirfd`, suppressed syscall errors, and bypassed embedded-NUL validation

This unblocks the remaining native Unix directory walker in `typescript-goish` while that consumer remains pinned to the released Goish alpha.10.
